### PR TITLE
fix issue where you couldn’t do an where statement with numeric strings

### DIFF
--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -288,7 +288,7 @@ class Grammar implements IGrammar
         // stringify all values if it has NOT an odata enum syntax
         // (ex. Microsoft.OData.SampleService.Models.TripPin.PersonGender'Female')
         if (!preg_match("/^([\w]+\.)+([\w]+)(\'[\w]+\')$/", $value)) {
-            if (!is_numeric($value)) {
+            if (is_string($value)) {
                 $value = "'".$where['value']."'";
             }
         }

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -288,7 +288,7 @@ class Grammar implements IGrammar
         // stringify all values if it has NOT an odata enum syntax
         // (ex. Microsoft.OData.SampleService.Models.TripPin.PersonGender'Female')
         if (!preg_match("/^([\w]+\.)+([\w]+)(\'[\w]+\')$/", $value)) {
-            if (is_string($value)) {
+            if (is_string($value) && !\DateTime::createFromFormat('U', $value)) {
                 $value = "'".$where['value']."'";
             }
         }

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -288,7 +288,8 @@ class Grammar implements IGrammar
         // stringify all values if it has NOT an odata enum syntax
         // (ex. Microsoft.OData.SampleService.Models.TripPin.PersonGender'Female')
         if (!preg_match("/^([\w]+\.)+([\w]+)(\'[\w]+\')$/", $value)) {
-            if (is_string($value) && !\DateTime::createFromFormat('U', $value)) {
+            // Check if the value is a string and NOT a date
+            if (is_string($value) && !\DateTime::createFromFormat('Y-m-d\TH:i:sT', $value)) {
                 $value = "'".$where['value']."'";
             }
         }


### PR DESCRIPTION
We were having trouble with the where conditions for strings with numbers and strings.

I saw that you added a check for `!is_numeric()`. This fails if I want to make such a query:

`ENDPOINT/ENTITY/$count?$filter=Id eq '1234'`

On our oData Endpoint, the Id is a string, not an Int but is using numbers. 

This is why I propose using `is_string` it allows the consumer to pass in a string and it will be quoted, if you pass in an int it wont be quoted.

Also the code gets a bit more readable.

WDYT?