### PR TITLE
Added support for canonical functions for both OData 4

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -438,6 +438,10 @@ class Builder
         // in our array and add the query binding to our array of bindings that
         // will be bound to each SQL statements when it is finally executed.
         $type = 'Basic';
+        if($this->isOperatorAFunction($operator)){
+            $type = 'Function';
+        }
+        
 
         $this->wheres[] = compact(
             'type', 'column', 'operator', 'value', 'boolean'
@@ -470,6 +474,17 @@ class Builder
                 }
             }
         }, $boolean);
+    }
+
+    /**
+     * Determine if the given operator is actually a function.
+     *
+     * @param  string $operator
+     * @return bool
+     */
+    protected function isOperatorAFunction($operator)
+    {
+        return in_array(strtolower($operator), $this->grammar->getFunctions(), true);
     }
 
     /**
@@ -519,7 +534,7 @@ class Builder
     protected function invalidOperator($operator)
     {
         return ! in_array(strtolower($operator), $this->operators, true) &&
-               ! in_array(strtolower($operator), $this->grammar->getOperators(), true);
+               ! in_array(strtolower($operator), $this->grammar->getOperatorsAndFunctions(), true);
     }
 
     /**

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -483,6 +483,8 @@ class Grammar implements IGrammar
             // Check if the value is a string and NOT a date
             if (is_string($value) && !\DateTime::createFromFormat('Y-m-d\TH:i:sT', $value)) {
                 $value = "'".$value."'";
+            } else if(is_bool($value)){
+                $value = $value ? 'true' : 'false';
             }
         }
 

--- a/src/Query/IGrammar.php
+++ b/src/Query/IGrammar.php
@@ -21,6 +21,29 @@ interface IGrammar
     public function getOperators();
 
     /**
+     * Get the grammar specific functions.
+     *
+     * @return array
+     */
+    public function getFunctions();
+
+    /**
+     * Get the grammar specific operators and functions.
+     *
+     * @return array
+     */
+    public function getOperatorsAndFunctions();
+
+    /**
+     * Prepare the appropriate URI value for a where value.
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    public function prepareValue($value);
+
+    /**
      * Get the appropriate query parameter place-holder for a value.
      *
      * @param mixed $value


### PR DESCRIPTION
Hi

I can see that canonical functions (ex: contains, startswith, endswith) as described here: http://docs.oasis-open.org/odata/odata/v4.0/odata-v4.0-part2-url-conventions.html are implemented but they are wrongly handled by whereBasic (as they are functions not operators).

I have separated them from operators into functions and created a new whereFunction to handle the filters in which the operator is actually a function.

Now one can do $client->where("Field", "contains", "foo") which will translate correctly to $filter=contains(Field,'foo').

Thanks.