### PR TITLE
Cast method to string as Enum class is no longer supported by guzzle

### DIFF
--- a/src/HttpRequestMessage.php
+++ b/src/HttpRequestMessage.php
@@ -46,9 +46,9 @@ class HttpRequestMessage
      */
     public $version;
 
-    public function __construct(HttpMethod $method = HttpMethod::GET, $requestUri = null)
+    public function __construct($method = HttpMethod::GET, $requestUri = null)
     {
-        $this->method = $method;
+        $this->method = (string)$method;
         $this->requestUri = $requestUri;
         $this->headers = [];
         $this->returnsStream = false;


### PR DESCRIPTION
Guzzle has added an assert for the request method to be a string.

```
private function assertMethod($method)
{
    if (!is_string($method) || $method === '') {
        throw new \InvalidArgumentException('Method must be a non-empty string.');
    }
}
```

The library is sending an Enum object which makes the guzzle assert fail and give errors.

I made sure we cast the method to string.