### PR TITLE
implemented Arrayable in Entity

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -34,7 +34,7 @@ use SaintSystems\OData\Exception\MassAssignmentException;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @version   Release: 0.1.0
 */
-class Entity implements ArrayAccess
+class Entity implements ArrayAccess, Arrayable
 {
     /**
      * The entity set name associated with the entity.


### PR DESCRIPTION
Entity should implement \Illuminate\Contracts\Support\Arrayable  
so `toArray` converts a collection to an array of arrays and not array of entities.