### PR TITLE
Add compatibility with laravel 7.x - #54

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.2",
         "guzzlehttp/guzzle": "^6.3",
         "nesbot/carbon": "^2.0",
-        "illuminate/support": "^5.8 || ^6.0"
+        "illuminate/support": "^5.8 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",


### PR DESCRIPTION
Projects running Laravel 7.x can't use this library due a restriction in composer.json. This pull request add the compatibility with illuminate/support 7.0 on package constraints.