### PR TITLE
Fix uuid validation

### DIFF
--- a/src/Core/helpers.php
+++ b/src/Core/helpers.php
@@ -176,6 +176,6 @@ if (!function_exists('http_build_url')) {
 if (!function_exists('is_uuid')) {
     function is_uuid($uuid)
     {
-        return preg_match('/[a-f0-9]{8}\-[a-f0-9]{4}\-[a-f0-9]{4}\-(8|9|a|b)[a-f0-9]{3}\-[a-f0-9]{12}/i', $uuid) == 1;
+        return preg_match('/^[a-f0-9]{8}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{12}$/i', $uuid) == 1;
     }
 }

--- a/tests/Core/HelpersTest.php
+++ b/tests/Core/HelpersTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SaintSystems\OData\Tests\Core;
+
+use PHPUnit\Framework\TestCase;
+
+class HelpersTest extends TestCase
+{
+    public function testIsUuid()
+    {
+        $this->assertTrue(
+            is_uuid('4291e9f7-dea1-eb11-b1ac-000d3ab7a7ea'),
+            'Normal UUID'
+        );
+        $this->assertTrue(
+            is_uuid('d9737e50-dad9-5b02-268b-4ddcf570108c'),
+            'Microsoft Dynamics CRM generated previously invalid UUID'
+        );
+        $this->assertFalse(
+            is_uuid('!4291e9f7-dea1-eb11-b1ac-000d3ab7a7eaLOL'),
+            'Invalid prefix and suffix'
+        );
+    }
+}


### PR DESCRIPTION
- detect superfluous suffixes and prefixes
- allow UUIDs generated by Microsoft Dynamics CRM that previously did not match

Resolves: https://github.com/saintsystems/odata-client-php/issues/85