### PR TITLE
Header should not be array in array 

### DIFF
--- a/src/ODataRequest.php
+++ b/src/ODataRequest.php
@@ -314,9 +314,7 @@ class ODataRequest implements IODataRequest
         ];
 
         if (!$this->isAggregate()) {
-            $headers[] = [
-                RequestHeader::ACCEPT => ContentType::APPLICATION_JSON,
-            ];
+            $headers[RequestHeader::ACCEPT] = RequestHeader::ACCEPT => ContentType::APPLICATION_JSON  ;
         }
         return $headers;
     }

--- a/src/ODataRequest.php
+++ b/src/ODataRequest.php
@@ -314,7 +314,7 @@ class ODataRequest implements IODataRequest
         ];
 
         if (!$this->isAggregate()) {
-            $headers[RequestHeader::ACCEPT] = RequestHeader::ACCEPT => ContentType::APPLICATION_JSON  ;
+            $headers[RequestHeader::ACCEPT] = ContentType::APPLICATION_JSON ;
         }
         return $headers;
     }


### PR DESCRIPTION
guzzlehttp/psr7/src/Utils.php added   declare(strict_types=1);
Header should not be array in array 
Key becomes 0 and exception is thrown in caselessRemove in Utils.php