### PR TITLE
Where raw

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.3 || ^8.0",
         "guzzlehttp/guzzle": "^7.0",
         "nesbot/carbon": "^2.0",
-        "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0 | ^9.0"
+        "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "guzzlehttp/guzzle": "^7.0",
         "nesbot/carbon": "^2.0",
         "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "saintsystems/odata-client",
-    "version": "0.5.2",
+    "version": "0.6.0",
     "description": "Saint Systems OData Client for PHP",
     "keywords": ["odata", "rest", "php"],
     "homepage": "https://github.com/saintsystems/odata-client-php",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.3 || ^8.0",
         "guzzlehttp/guzzle": "^7.0",
         "nesbot/carbon": "^2.0",
-        "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0"
+        "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0 | ^9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -816,7 +816,7 @@ class Entity implements ArrayAccess, Arrayable
      * @param  mixed  $offset
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->$offset);
     }
@@ -827,7 +827,7 @@ class Entity implements ArrayAccess, Arrayable
      * @param  mixed  $offset
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->$offset;
     }
@@ -839,7 +839,7 @@ class Entity implements ArrayAccess, Arrayable
      * @param  mixed  $value
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->$offset = $value;
     }
@@ -850,7 +850,7 @@ class Entity implements ArrayAccess, Arrayable
      * @param  mixed  $offset
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->$offset);
     }

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -816,7 +816,7 @@ class Entity implements ArrayAccess, Arrayable
      * @param  mixed  $offset
      * @return bool
      */
-    public function offsetExists($offset): bool
+    public function offsetExists($offset)
     {
         return isset($this->$offset);
     }
@@ -827,7 +827,7 @@ class Entity implements ArrayAccess, Arrayable
      * @param  mixed  $offset
      * @return mixed
      */
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->$offset;
     }
@@ -839,7 +839,7 @@ class Entity implements ArrayAccess, Arrayable
      * @param  mixed  $value
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet($offset, $value)
     {
         $this->$offset = $value;
     }
@@ -850,7 +850,7 @@ class Entity implements ArrayAccess, Arrayable
      * @param  mixed  $offset
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset($offset)
     {
         unset($this->$offset);
     }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -550,6 +550,25 @@ class Builder
         return $this->where($column, $operator, $value, 'or');
     }
 
+    public function whereRaw($rawString, $boolean = 'and')
+    {
+        // We will add this where clause into this array of clauses that we
+        // are building for the query. All of them will be compiled via a grammar
+        // once the query is about to be executed and run against the database.
+        $type = 'Raw';
+
+        $this->wheres[] = compact(
+            'type', 'rawString', 'boolean'
+        );
+
+        return $this;
+    }
+
+    public function orWhereRaw($rawString)
+    {
+        return $this->whereRaw($rawString, 'or');
+    }
+
     /**
      * Add a "where" clause comparing two columns to the query.
      *

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -286,6 +286,11 @@ class Grammar implements IGrammar
         })->all();
     }
 
+    protected function whereRaw(Builder $query, $where)
+    {
+        return $where['rawString'];
+    }
+
     /**
      * Format the where clause statements into one string.
      *


### PR DESCRIPTION
When using more complex statements with data types like "DateTime" it will be quoted using normal where statements.
This is not desirable so when using whereRaw it is possible to prevent quoting.