### PR TITLE
Fix response body retrieval in combination with logging

### DIFF
--- a/src/ODataRequest.php
+++ b/src/ODataRequest.php
@@ -222,14 +222,14 @@ class ODataRequest implements IODataRequest
         }
 
         if ($this->isAggregate()) {
-            return $result->getBody()->getContents();
+            return (string) $result->getBody();
         }
 
         // Wrap response in ODataResponse layer
         try {
             $response = new ODataResponse(
                 $this,
-                $result->getBody()->getContents(),
+                (string) $result->getBody(),
                 $result->getStatusCode(),
                 $result->getHeaders()
             );
@@ -275,7 +275,7 @@ class ODataRequest implements IODataRequest
             function ($result) {
                 $response = new ODataResponse(
                     $this,
-                    $result->getBody()->getContents(),
+                    (string) $result->getBody(),
                     $result->getStatusCode(),
                     $result->getHeaders()
                 );


### PR DESCRIPTION
All HTTP responses are empty when configuring HTTP request logging by
creating a GuzzleHttp\HandlerStack,
adding a logger created by \GuzzleHttp\Middleware::log()
and setting the stack in the "handler" extra option in GuzzleHttpProvider.

Guzzle's $result->getBody() returns a StreamInterface, and its
getContents() method docs says:
> Returns the remaining contents in a string

Since the logger in the handler stack already accessed the
response body, getContents() returns an empty string.

The correct way to access the full response body is using the
__toString() method, which is invoked by casting it to a string.

This patch correctly casts the response body stream to a string
instead of using getContents().

More information:
- https://github.com/guzzle/guzzle/pull/1262
  rewind the stream after logging #1262
- https://michaelstivala.com/logging-guzzle-requests/
  "A short note on working with Guzzle responses"

----

Example code for HTTP request logging
```
$stack = \GuzzleHttp\HandlerStack::create();

$stack->push(
    \GuzzleHttp\Middleware::log(
        Log::channel('crmlogger'),
        new \GuzzleHttp\MessageFormatter(
            "{method} {uri}\n"
            . " REQ {req_body}\n"
            . " RES {code} \"{phrase}\" {res_body}"
        )
    )
);
$httpProvider = new \SaintSystems\OData\GuzzleHttpProvider();
$httpProvider->setExtraOptions(['handler' => $stack]);

$client = new ODataClient($myBaseUrl, function ($request) {}, $httpProvider);
```