### PR TITLE
remove 'mixed' type declarations

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -828,7 +828,7 @@ class Entity implements ArrayAccess, Arrayable
      * @param  mixed  $offset
      * @return mixed
      */
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->$offset;
     }


### PR DESCRIPTION
Remove the `mixed` type from the `offsetGet()` function declaration. This maintains compatibility with PHP 7.4 because the mixed type isn't supported until PHP 8.0. 
PR #135 removed the mixed type declaration from function parameters, we just need to remove one more instance from the function return declaration.