### PR TITLE
Body decode fix

### DIFF
--- a/src/ODataResponse.php
+++ b/src/ODataResponse.php
@@ -76,7 +76,7 @@ class ODataResponse
         $this->body = $body;
         $this->httpStatusCode = $httpStatusCode;
         $this->headers = $headers;
-        $this->decodedBody = $this->decodeBody();
+        $this->decodedBody = $this->body ? $this->decodeBody() : [];
     }
 
     /**


### PR DESCRIPTION
In case of empty body (e.g. `HTTP 204` for DELETE). This `decodeBody` regex fails and throws an error.

The fix is to NOT decode an empty body.