### PR TITLE
PHP 8.2 compatibility fix

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -828,6 +828,7 @@ class Entity implements ArrayAccess, Arrayable
      * @param  mixed  $offset
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->$offset;

--- a/src/ODataResponse.php
+++ b/src/ODataResponse.php
@@ -76,7 +76,7 @@ class ODataResponse
         $this->body = $body;
         $this->httpStatusCode = $httpStatusCode;
         $this->headers = $headers;
-        $this->decodedBody = $this->decodeBody();
+        $this->decodedBody = $this->body ? $this->decodeBody() : [];
     }
 
     /**


### PR DESCRIPTION
Latest changes for PHP 7.4 broke compatibility for PHP 8.1/8.2:

During inheritance of ArrayAccess: Uncaught Return type of SaintSystems\OData\Entity::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

This error occurs only when trying to subclass `SaintSystems\OData\Entity` that's why it was not caught by the unit tests.