### PR TITLE
Add support for odata paging using LazyCollection over @odata.nextLink

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^7.3 || ^8.0",
         "guzzlehttp/guzzle": "^7.0",
         "nesbot/carbon": "^2.0",
-        "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -19,7 +19,7 @@ namespace SaintSystems\OData;
 
 class Constants
 {
-    const SDK_VERSION = '0.5.2';
+    const SDK_VERSION = '0.6.7';
 
     // ODATA Versions to be used when accessing the Web API (see: https://msdn.microsoft.com/en-us/library/gg334391.aspx)
     const MAX_ODATA_VERSION = '4.0';

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -1,16 +1,18 @@
 <?php
+
 /**
-* Copyright (c) Saint Systems, LLC.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
-*
-* OData Entity File
-* PHP version 7
-*
-* @category  Library
-* @package   SaintSystems.OData
-* @copyright 2017 Saint Systems, LLC
-* @license   https://opensource.org/licenses/MIT MIT License
-* @version   GIT: 0.1.0
-*/
+ * Copyright (c) Saint Systems, LLC.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+ *
+ * OData Entity File
+ * PHP version 7
+ *
+ * @category  Library
+ * @package   SaintSystems.OData
+ * @copyright 2017 Saint Systems, LLC
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @version   GIT: 0.1.0
+ */
+
 namespace SaintSystems\OData;
 
 // use Closure;
@@ -28,13 +30,13 @@ use Illuminate\Support\Facades\Date;
 use SaintSystems\OData\Exception\MassAssignmentException;
 
 /**
-* Entity class
-*
-* @package   SaintSystems.OData
-* @copyright 2017 Saint Systems, LLC
-* @license   https://opensource.org/licenses/MIT MIT License
-* @version   Release: 0.1.0
-*/
+ * Entity class
+ *
+ * @package   SaintSystems.OData
+ * @copyright 2017 Saint Systems, LLC
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @version   Release: 0.1.0
+ */
 class Entity implements ArrayAccess, Arrayable
 {
     /**
@@ -124,7 +126,7 @@ class Entity implements ArrayAccess, Arrayable
      *
      * @var array
      */
-    protected $guarded = [];//['*'];
+    protected $guarded = []; //['*'];
 
     /**
      * The properties that should be mutated to dates.
@@ -186,12 +188,12 @@ class Entity implements ArrayAccess, Arrayable
     private $entity;
 
     /**
-    * Construct a new Entity
-    *
-    * @param array $properties A list of properties to set
-    *
-    * @return Entity
-    */
+     * Construct a new Entity
+     *
+     * @param array $properties A list of properties to set
+     *
+     * @return Entity
+     */
     function __construct($properties = array())
     {
         $this->bootIfNotBooted();
@@ -210,7 +212,7 @@ class Entity implements ArrayAccess, Arrayable
      */
     protected function bootIfNotBooted()
     {
-        if (! isset(static::$booted[static::class])) {
+        if (!isset(static::$booted[static::class])) {
             static::$booted[static::class] = true;
 
             // $this->fireModelEvent('booting', false);
@@ -241,7 +243,7 @@ class Entity implements ArrayAccess, Arrayable
         $class = static::class;
 
         foreach (class_uses_recursive($class) as $trait) {
-            if (method_exists($class, $method = 'boot'.class_basename($trait))) {
+            if (method_exists($class, $method = 'boot' . class_basename($trait))) {
                 forward_static_call([$class, $method]);
             }
         }
@@ -307,7 +309,7 @@ class Entity implements ArrayAccess, Arrayable
      */
     protected function fillableFromArray(array $properties)
     {
-        if (count($this->getFillable()) > 0 && ! static::$unguarded) {
+        if (count($this->getFillable()) > 0 && !static::$unguarded) {
             return array_intersect_key($properties, array_flip($this->getFillable()));
         }
 
@@ -463,7 +465,7 @@ class Entity implements ArrayAccess, Arrayable
     {
         $this->hidden = array_diff($this->hidden, (array) $properties);
 
-        if (! empty($this->visible)) {
+        if (!empty($this->visible)) {
             $this->addVisible($properties);
         }
 
@@ -699,7 +701,7 @@ class Entity implements ArrayAccess, Arrayable
             return false;
         }
 
-        return empty($this->getFillable()) && ! Str::startsWith($key, '_');
+        return empty($this->getFillable()) && !Str::startsWith($key, '_');
     }
 
     /**
@@ -724,10 +726,10 @@ class Entity implements ArrayAccess, Arrayable
     }
 
     /**
-    * Gets the property dictionary of the Entity
-    *
-    * @return array The list of properties
-    */
+     * Gets the property dictionary of the Entity
+     *
+     * @return array The list of properties
+     */
     public function getProperties()
     {
         return $this->properties;
@@ -865,7 +867,7 @@ class Entity implements ArrayAccess, Arrayable
      */
     public function __isset($key)
     {
-        return ! is_null($this->getProperty($key));
+        return !is_null($this->getProperty($key));
     }
 
     /**
@@ -977,7 +979,7 @@ class Entity implements ArrayAccess, Arrayable
             case 'array':
             case 'json':
                 return $this->fromJson($value);
-            //case 'collection':
+                //case 'collection':
                 //return new BaseCollection($this->fromJson($value));
             case 'date':
                 return $this->asDate($value);
@@ -1004,7 +1006,7 @@ class Entity implements ArrayAccess, Arrayable
         // which simply lets the developers tweak the property as it is set on
         // the entity, such as "json_encoding" a listing of data for storage.
         if ($this->hasSetMutator($key)) {
-            $method = 'set'.Str::studly($key).'Property';
+            $method = 'set' . Str::studly($key) . 'Property';
 
             return $this->{$method}($value);
         }
@@ -1016,7 +1018,7 @@ class Entity implements ArrayAccess, Arrayable
             $value = $this->fromDateTime($value);
         }
 
-        if ($this->isJsonCastable($key) && ! is_null($value)) {
+        if ($this->isJsonCastable($key) && !is_null($value)) {
             $value = $this->asJson($value);
         }
 
@@ -1040,7 +1042,7 @@ class Entity implements ArrayAccess, Arrayable
      */
     public function hasSetMutator($key)
     {
-        return method_exists($this, 'set'.Str::studly($key).'Property');
+        return method_exists($this, 'set' . Str::studly($key) . 'Property');
     }
 
     /**
@@ -1086,7 +1088,8 @@ class Entity implements ArrayAccess, Arrayable
         // when checking the field. We will just return the DateTime right away.
         if ($value instanceof DateTimeInterface) {
             return Date::parse(
-                $value->format('Y-m-d H:i:s.u'), $value->getTimezone()
+                $value->format('Y-m-d H:i:s.u'),
+                $value->getTimezone()
             );
         }
         // If this value is an integer, we will assume it is a UNIX timestamp's value
@@ -1165,7 +1168,7 @@ class Entity implements ArrayAccess, Arrayable
      */
     protected function getDateFormat()
     {
-        return $this->dateFormat;// ?: $this->getConnection()->getQueryGrammar()->getDateFormat();
+        return $this->dateFormat; // ?: $this->getConnection()->getQueryGrammar()->getDateFormat();
     }
 
     /**
@@ -1201,7 +1204,7 @@ class Entity implements ArrayAccess, Arrayable
      */
     public function fromJson($value, $asObject = false)
     {
-        return json_decode($value, ! $asObject);
+        return json_decode($value, !$asObject);
     }
 
     /**
@@ -1313,7 +1316,7 @@ class Entity implements ArrayAccess, Arrayable
     protected function addDatePropertiesToArray(array $properties)
     {
         foreach ($this->getDates() as $key) {
-            if (! isset($properties[$key])) {
+            if (!isset($properties[$key])) {
                 continue;
             }
 
@@ -1338,7 +1341,7 @@ class Entity implements ArrayAccess, Arrayable
             // We want to spin through all the mutated properties for this model and call
             // the mutator for the properties. We cache off every mutated properties so
             // we don't have to constantly check on properties that actually change.
-            if (! array_key_exists($key, $properties)) {
+            if (!array_key_exists($key, $properties)) {
                 continue;
             }
 
@@ -1346,7 +1349,8 @@ class Entity implements ArrayAccess, Arrayable
             // mutated property's actual values. After we finish mutating each of the
             // properties we will return this final array of the mutated properties.
             $properties[$key] = $this->mutatePropertyForArray(
-                $key, $properties[$key]
+                $key,
+                $properties[$key]
             );
         }
 
@@ -1363,7 +1367,7 @@ class Entity implements ArrayAccess, Arrayable
     protected function addCastPropertiesToArray(array $properties, array $mutatedProperties)
     {
         foreach ($this->getCasts() as $key => $value) {
-            if (! array_key_exists($key, $properties) || in_array($key, $mutatedProperties)) {
+            if (!array_key_exists($key, $properties) || in_array($key, $mutatedProperties)) {
                 continue;
             }
 
@@ -1371,14 +1375,17 @@ class Entity implements ArrayAccess, Arrayable
             // then we will serialize the date for the array. This will convert the dates
             // to strings based on the date format specified for these Entity models.
             $properties[$key] = $this->castProperty(
-                $key, $properties[$key]
+                $key,
+                $properties[$key]
             );
 
             // If the property cast was a date or a datetime, we will serialize the date as
             // a string. This allows the developers to customize how dates are serialized
             // into an array without affecting how they are persisted into the storage.
-            if ($properties[$key] &&
-                ($value === 'date' || $value === 'datetime')) {
+            if (
+                $properties[$key] &&
+                ($value === 'date' || $value === 'datetime')
+            ) {
                 $properties[$key] = $this->serializeDate($properties[$key]);
             }
         }
@@ -1403,7 +1410,7 @@ class Entity implements ArrayAccess, Arrayable
      */
     protected function getArrayableAppends()
     {
-        if (! count($this->appends)) {
+        if (!count($this->appends)) {
             return [];
         }
 
@@ -1493,7 +1500,7 @@ class Entity implements ArrayAccess, Arrayable
      */
     public function getProperty($key)
     {
-        if (! $key) {
+        if (!$key) {
             return;
         }
 
@@ -1504,8 +1511,10 @@ class Entity implements ArrayAccess, Arrayable
         // If the property exists in the properties array or has a "get" mutator we will
         // get the property's value. Otherwise, we will proceed as if the developers
         // are asking for a relationship's value. This covers both types of values.
-        if (array_key_exists($key, $this->properties) ||
-            $this->hasGetMutator($key)) {
+        if (
+            array_key_exists($key, $this->properties) ||
+            $this->hasGetMutator($key)
+        ) {
             return $this->getPropertyValue($key);
         }
 
@@ -1547,8 +1556,10 @@ class Entity implements ArrayAccess, Arrayable
         // If the property is listed as a date, we will convert it to a DateTime
         // instance on retrieval, which makes it quite convenient to work with
         // date fields without having to create a mutator for each property.
-        if (in_array($key, $this->getDates()) &&
-            ! is_null($value)) {
+        if (
+            in_array($key, $this->getDates()) &&
+            !is_null($value)
+        ) {
             return $this->asDateTime($value);
         }
 
@@ -1576,7 +1587,7 @@ class Entity implements ArrayAccess, Arrayable
      */
     public function hasGetMutator($key)
     {
-        return method_exists($this, 'get'.Str::studly($key).'Property');
+        return method_exists($this, 'get' . Str::studly($key) . 'Property');
         //return method_exists($this, 'get_'.$key);
     }
 
@@ -1589,7 +1600,7 @@ class Entity implements ArrayAccess, Arrayable
      */
     protected function mutateProperty($key, $value)
     {
-        return $this->{'get'.Str::studly($key).'Property'}($value);
+        return $this->{'get' . Str::studly($key) . 'Property'}($value);
         // return $this->{'get_'.$key}($value);
     }
 

--- a/src/IODataClient.php
+++ b/src/IODataClient.php
@@ -14,6 +14,38 @@ interface IODataClient
     public function getAuthenticationProvider();
 
     /**
+     * Set the odata.maxpagesize value of the request.
+     *
+     * @param int $pageSize
+     *
+     * @return IODataClient
+     */
+    public function setPageSize($pageSize);
+
+    /**
+     * Gets the page size
+     *
+     * @return int
+     */
+    public function getPageSize();
+
+    /**
+     * Set the entityKey to be found.
+     *
+     * @param mixed $entityKey
+     *
+     * @return IODataClient
+     */
+    public function setEntityKey($entityKey);
+
+    /**
+     * Gets the entity key
+     *
+     * @return mixed
+     */
+    public function getEntityKey();
+
+    /**
      * Gets the base URL for requests of the client.
      * @var string
      */

--- a/src/IODataClient.php
+++ b/src/IODataClient.php
@@ -51,12 +51,34 @@ interface IODataClient
     public function query();
 
     /**
+     * Run a GET HTTP request against the service.
+     *
      * @param $requestUri
      * @param array $bindings
      *
      * @return IODataRequest
      */
     public function get($requestUri, $bindings = []);
+
+    /**
+     * Run a GET HTTP request against the service.
+     *
+     * @param $requestUri
+     * @param array $bindings
+     *
+     * @return IODataRequest
+     */
+    public function getNextPage($requestUri, $bindings = []);
+
+    /**
+     * Run a GET HTTP request against the service and return a generator
+     *
+     * @param $requestUri
+     * @param array $bindings
+     *
+     * @return IODataRequest
+     */
+    public function cursor($requestUri, $bindings = []);
 
     /**
      * Get the query grammar used by the connection.

--- a/src/ODataClient.php
+++ b/src/ODataClient.php
@@ -53,6 +53,20 @@ class ODataClient implements IODataClient
     private $entityReturnType;
 
     /**
+     * The page size
+     *
+     * @var int
+     */
+    private $pageSize;
+
+    /**
+     * The entityKey to be found
+     *
+     * @var mixed
+     */
+    private $entityKey;
+
+    /**
      * Constructs a new ODataClient.
      * @param string                  $baseUrl                The base service URL.
      * @param IAuthenticationProvider $authenticationProvider The IAuthenticationProvider for authenticating request messages.
@@ -365,5 +379,47 @@ class ODataClient implements IODataClient
     public function setEntityReturnType($entityReturnType)
     {
         $this->entityReturnType = $entityReturnType;
+    }
+
+    /**
+     * Set the odata.maxpagesize value of the request.
+     *
+     * @param int $pageSize
+     *
+     * @return IODataClient
+     */
+    public function setPageSize($pageSize) {
+        $this->pageSize = $pageSize;
+        return $this;
+    }
+
+    /**
+     * Gets the page size
+     *
+     * @return int
+     */
+    public function getPageSize() {
+        return $this->pageSize;
+    }
+
+    /**
+     * Set the entityKey to be found.
+     *
+     * @param mixed $entityKey
+     *
+     * @return IODataClient
+     */
+    public function setEntityKey($entityKey) {
+        $this->entityKey = $entityKey;
+        return $this;
+    }
+
+    /**
+     * Gets the entity key
+     *
+     * @return mixed
+     */
+    public function getEntityKey() {
+        return $this->entityKey;
     }
 }

--- a/src/ODataClient.php
+++ b/src/ODataClient.php
@@ -228,7 +228,7 @@ class ODataClient implements IODataClient
     }
 
     /**
-     * Run a GET HTTP request against the service and return a generator
+     * Run a GET HTTP request against the service and return a generator.
      *
      * @param string $requestUri
      * @param array  $bindings

--- a/src/ODataRequest.php
+++ b/src/ODataRequest.php
@@ -97,6 +97,20 @@ class ODataRequest implements IODataRequest
         }
         $this->timeout = 0;
         $this->headers = $this->getDefaultHeaders();
+        $pageSize = $this->client->getPageSize();
+        if (!is_null($pageSize) && is_int($pageSize)) {
+            $this->setPageSize($pageSize);
+        }
+    }
+
+    /**
+     * Undocumented function
+     *
+     * @param [type] $pageSize
+     * @return void
+     */
+    public function setPageSize($pageSize) {
+        $this->headers[RequestHeader::PREFER] = Constants::ODATA_MAX_PAGE_SIZE . '=' . $pageSize;
     }
 
     /**
@@ -215,7 +229,15 @@ class ODataRequest implements IODataRequest
 
         $this->authenticateRequest($request);
 
+        // if (strpos($this->requestUrl, '$skiptoken') !== false) {
+            // echo PHP_EOL;
+            // echo 'Sending request: '. $this->requestUrl;
+            // echo PHP_EOL;
+        // }
         $result = $this->client->getHttpProvider()->send($request);
+
+        // Reset
+        $this->client->setEntityKey(null);
 
         //Send back the bare response
         if ($this->returnsStream) {
@@ -247,7 +269,7 @@ class ODataRequest implements IODataRequest
             $returnObj = $response->getResponseAsObject($returnType);
         }
         $nextLink = $response->getNextLink();
-        //return $returnObj;
+
         return [$returnObj, $nextLink];
     }
 
@@ -307,13 +329,11 @@ class ODataRequest implements IODataRequest
     private function getDefaultHeaders()
     {
         $headers = [
-            //RequestHeader::HOST => $this->client->getBaseUrl(),
             RequestHeader::CONTENT_TYPE => ContentType::APPLICATION_JSON,
             RequestHeader::ODATA_MAX_VERSION => Constants::MAX_ODATA_VERSION,
             RequestHeader::ODATA_VERSION => Constants::ODATA_VERSION,
-            RequestHeader::PREFER => Constants::ODATA_MAX_PAGE_SIZE_DEFAULT,
+            RequestHeader::PREFER => Constants::ODATA_MAX_PAGE_SIZE . '=' . Constants::ODATA_MAX_PAGE_SIZE_DEFAULT,
             RequestHeader::USER_AGENT => 'odata-sdk-php-' . Constants::SDK_VERSION,
-            //RequestHeader::AUTHORIZATION => 'Bearer ' . $this->accessToken
         ];
 
         if (!$this->isAggregate()) {
@@ -351,7 +371,7 @@ class ODataRequest implements IODataRequest
     private function addHeadersToRequest(HttpRequestMessage $request)
     {
         $request->headers = array_merge($this->headers, $request->headers);
-        if (strpos($request->requestUri, '/$count') !== false) {
+        if (strpos($request->requestUri, '/$count') !== false || !is_null($this->client->getEntityKey())) {
             $request->headers = array_filter($request->headers, function($key) {
                 return $key !== RequestHeader::PREFER;
              }, ARRAY_FILTER_USE_KEY);

--- a/src/ODataResponse.php
+++ b/src/ODataResponse.php
@@ -1,19 +1,20 @@
 <?php
+
 /**
-* Copyright (c) Saint Systems, LLC.  All Rights Reserved.
-* Licensed under the MIT License.  See License in the project root
-* for license information.
-*
-* ODataResponse File
-* PHP version 7
-*
-* @category  Library
-* @package   SaintSystems.OData
-* @copyright 2017 Saint Systems, LLC
-* @license   https://opensource.org/licenses/MIT MIT License
-* @version   GIT: 0.1.0
-* @link      https://www.microsoft.com/en-us/OData365/
-*/
+ * Copyright (c) Saint Systems, LLC.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ *
+ * ODataResponse File
+ * PHP version 7
+ *
+ * @category  Library
+ * @package   SaintSystems.OData
+ * @copyright 2017 Saint Systems, LLC
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @version   GIT: 0.1.0
+ * @link      https://www.microsoft.com/en-us/OData365/
+ */
 
 namespace SaintSystems\OData;
 
@@ -27,49 +28,49 @@ namespace SaintSystems\OData;
 class ODataResponse
 {
     /**
-    * The request
-    *
-    * @var object
-    */
+     * The request
+     *
+     * @var object
+     */
     public $request;
 
     /**
-    * The body of the response
-    *
-    * @var string
-    */
+     * The body of the response
+     *
+     * @var string
+     */
     private $body;
 
     /**
-    * The body of the response,
-    * decoded into an array
-    *
-    * @var array(string)
-    */
+     * The body of the response,
+     * decoded into an array
+     *
+     * @var array(string)
+     */
     private $decodedBody;
 
     /**
-    * The headers of the response
-    *
-    * @var array(string)
-    */
+     * The headers of the response
+     *
+     * @var array(string)
+     */
     private $headers;
 
     /**
-    * The status code of the response
-    *
-    * @var string
-    */
+     * The status code of the response
+     *
+     * @var string
+     */
     private $httpStatusCode;
 
     /**
-    * Creates a new OData HTTP response entity
-    *
-    * @param object $request        The request
-    * @param string $body           The body of the response
-    * @param string $httpStatusCode The returned status code
-    * @param array  $headers        The returned headers
-    */
+     * Creates a new OData HTTP response entity
+     *
+     * @param object $request        The request
+     * @param string $body           The body of the response
+     * @param string $httpStatusCode The returned status code
+     * @param array  $headers        The returned headers
+     */
     public function __construct($request, $body = null, $httpStatusCode = null, $headers = array())
     {
         $this->request = $request;
@@ -80,10 +81,10 @@ class ODataResponse
     }
 
     /**
-    * Decode the JSON response into an array
-    *
-    * @return array The decoded response
-    */
+     * Decode the JSON response into an array
+     *
+     * @return array The decoded response
+     */
     private function decodeBody()
     {
         $decodedBody = json_decode($this->body, true);
@@ -91,8 +92,7 @@ class ODataResponse
             $matches = null;
             preg_match('~\{(?:[^{}]|(?R))*\}~', $this->body, $matches);
             $decodedBody = json_decode($matches[0], true);
-            if ($decodedBody === null)
-            {
+            if ($decodedBody === null) {
                 $decodedBody = array();
             }
         }
@@ -100,52 +100,52 @@ class ODataResponse
     }
 
     /**
-    * Get the decoded body of the HTTP response
-    *
-    * @return array The decoded body
-    */
+     * Get the decoded body of the HTTP response
+     *
+     * @return array The decoded body
+     */
     public function getBody()
     {
         return $this->decodedBody;
     }
 
     /**
-    * Get the undecoded body of the HTTP response
-    *
-    * @return string The undecoded body
-    */
+     * Get the undecoded body of the HTTP response
+     *
+     * @return string The undecoded body
+     */
     public function getRawBody()
     {
         return $this->body;
     }
 
     /**
-    * Get the status of the HTTP response
-    *
-    * @return string The HTTP status
-    */
+     * Get the status of the HTTP response
+     *
+     * @return string The HTTP status
+     */
     public function getStatus()
     {
         return $this->httpStatusCode;
     }
 
     /**
-    * Get the headers of the response
-    *
-    * @return array The response headers
-    */
+     * Get the headers of the response
+     *
+     * @return array The response headers
+     */
     public function getHeaders()
     {
         return $this->headers;
     }
 
     /**
-    * Converts the response JSON object to a OData SDK object
-    *
-    * @param mixed $returnType The type to convert the object(s) to
-    *
-    * @return mixed object or array of objects of type $returnType
-    */
+     * Converts the response JSON object to a OData SDK object
+     *
+     * @param mixed $returnType The type to convert the object(s) to
+     *
+     * @return mixed object or array of objects of type $returnType
+     */
     public function getResponseAsObject($returnType)
     {
         $class = $returnType;
@@ -164,10 +164,10 @@ class ODataResponse
     }
 
     /**
-    * Gets the @odata.nextLink of a response object from OData
-    *
-    * @return string next link, if provided
-    */
+     * Gets the @odata.nextLink of a response object from OData
+     *
+     * @return string next link, if provided
+     */
     public function getNextLink()
     {
         if (array_key_exists(Constants::ODATA_NEXT_LINK, $this->getBody())) {
@@ -178,10 +178,10 @@ class ODataResponse
     }
 
     /**
-    * Gets the skip token of a response object from OData
-    *
-    * @return string skip token, if provided
-    */
+     * Gets the skip token of a response object from OData
+     *
+     * @return string skip token, if provided
+     */
     public function getSkipToken()
     {
         $nextLink = $this->getNextLink();
@@ -197,10 +197,10 @@ class ODataResponse
     }
 
     /**
-    * Gets the Id of response object (if set) from OData
-    *
-    * @return mixed id if this was an insert, if provided
-    */
+     * Gets the Id of response object (if set) from OData
+     *
+     * @return mixed id if this was an insert, if provided
+     */
     public function getId()
     {
         if (array_key_exists(Constants::ODATA_ID, $this->getHeaders())) {

--- a/src/ODataResponse.php
+++ b/src/ODataResponse.php
@@ -1,9 +1,9 @@
-<?php 
+<?php
 /**
-* Copyright (c) Saint Systems, LLC.  All Rights Reserved.  
-* Licensed under the MIT License.  See License in the project root 
+* Copyright (c) Saint Systems, LLC.  All Rights Reserved.
+* Licensed under the MIT License.  See License in the project root
 * for license information.
-* 
+*
 * ODataResponse File
 * PHP version 7
 *
@@ -32,7 +32,7 @@ class ODataResponse
     * @var object
     */
     public $request;
-    
+
     /**
     * The body of the response
     *
@@ -41,7 +41,7 @@ class ODataResponse
     private $body;
 
     /**
-    * The body of the response, 
+    * The body of the response,
     * decoded into an array
     *
     * @var array(string)
@@ -164,20 +164,34 @@ class ODataResponse
     }
 
     /**
+    * Gets the @odata.nextLink of a response object from OData
+    *
+    * @return string next link, if provided
+    */
+    public function getNextLink()
+    {
+        if (array_key_exists(Constants::ODATA_NEXT_LINK, $this->getBody())) {
+            $nextLink = $this->getBody()[Constants::ODATA_NEXT_LINK];
+            return $nextLink;
+        }
+        return null;
+    }
+
+    /**
     * Gets the skip token of a response object from OData
     *
     * @return string skip token, if provided
     */
     public function getSkipToken()
     {
-        if (array_key_exists(Constants::ODATA_NEXT_LINK, $this->getBody())) {
-            $nextLink = $this->getBody()[Constants::ODATA_NEXT_LINK];
-            $url = explode("?", $nextLink)[1];
-            $url = explode("skiptoken=", $url);
-            if (count($url) > 1) {
-                return $url[1];
-            }
+        $nextLink = $this->getNextLink();
+        if (is_null($nextLink)) {
             return null;
+        };
+        $url = explode("?", $nextLink)[1];
+        $url = explode("skiptoken=", $url);
+        if (count($url) > 1) {
+            return $url[1];
         }
         return null;
     }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -5,6 +5,7 @@ namespace SaintSystems\OData\Query;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
 use SaintSystems\OData\Constants;
 use SaintSystems\OData\Exception\ODataQueryException;
 use SaintSystems\OData\IODataClient;
@@ -120,6 +121,13 @@ class Builder
      * @var int
      */
     public $skip;
+
+    /**
+     * The skiptoken.
+     *
+     * @var int
+     */
+    public $skiptoken;
 
     /**
      * All of the available clause operators.
@@ -880,6 +888,19 @@ class Builder
     }
 
     /**
+     * Set the "$skiptoken" value of the query.
+     *
+     * @param int $value
+     *
+     * @return Builder|static
+     */
+    public function skipToken($value)
+    {
+        $this->skiptoken = $value;
+        return $this;
+    }
+
+    /**
      * Set the "$top" value of the query.
      *
      * @param int $value
@@ -1025,6 +1046,20 @@ class Builder
         return $this->client->get(
             $this->grammar->compileSelect($this), $this->getBindings()
         );
+    }
+
+    /**
+     * Get a lazy collection for the given request.
+     *
+     * @return \Illuminate\Support\LazyCollection
+     */
+    public function cursor()
+    {
+        return new LazyCollection(function() {
+            yield from $this->client->cursor(
+                $this->grammar->compileSelect($this), $this->getBindings()
+            );
+        });
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -116,6 +116,13 @@ class Builder
     public $take;
 
     /**
+     * The desired page size.
+     *
+     * @var int
+     */
+    public $pageSize;
+
+    /**
      * The number of records to skip.
      *
      * @var int
@@ -234,7 +241,7 @@ class Builder
     public function whereKey($id)
     {
         $this->entityKey = $id;
-
+        $this->client->setEntityKey($this->entityKey);
         return $this;
     }
 
@@ -910,6 +917,20 @@ class Builder
     public function take($value)
     {
         $this->take = $value;
+        return $this;
+    }
+
+    /**
+     * Set the desired pagesize of the query;
+     *
+     * @param int $value
+     *
+     * @return Builder|static
+     */
+    public function pageSize($value)
+    {
+        $this->pageSize = $value;
+        $this->client->setPageSize($this->pageSize);
         return $this;
     }
 

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -50,6 +50,7 @@ class Grammar implements IGrammar
         //'search',
         'orders',
         'skip',
+        'skiptoken',
         'take',
         'totalCount',
     ];
@@ -177,6 +178,7 @@ class Grammar implements IGrammar
                 || isset($query->expands)
                 || isset($query->take)
                 || isset($query->skip)
+                || isset($query->skiptoken)
             )) {
             return $queryString;
         }
@@ -418,6 +420,19 @@ class Grammar implements IGrammar
     protected function compileSkip(Builder $query, $skip)
     {
         return $this->appendQueryParam('$skip=') . (int) $skip;
+    }
+
+    /**
+     * Compile the "$skiptoken" portions of the query.
+     *
+     * @param Builder $query
+     * @param int     $skip
+     *
+     * @return string
+     */
+    protected function compileSkipToken(Builder $query, $skiptoken)
+    {
+        return $this->appendQueryParam('$skiptoken=') . (int) $skiptoken;
     }
 
     /**

--- a/tests/ODataClientTest.php
+++ b/tests/ODataClientTest.php
@@ -118,31 +118,21 @@ class ODataClientTest extends TestCase
         $page1response = $odataClient->from('People')->get()->first();
         $page1results = collect($page1response->getResponseAsObject(Entity::class));
         $this->assertEquals($page1results->count(), 8);
-        // $page1results->each(function($person) {
-        //     echo PHP_EOL . $person->FirstName . ' ' . $person->LastName;
-        // });
-        // echo PHP_EOL;
+
         $page1skiptoken = $page1response->getSkipToken();
         if ($page1skiptoken) {
             $page2response = $odataClient->from('People')->skiptoken($page1skiptoken)->get()->first();
             $page2results = collect($page2response->getResponseAsObject(Entity::class));
             $page2skiptoken = $page2response->getSkipToken();
             $this->assertEquals($page2results->count(), 8);
-            // $page2results->each(function($person) {
-            //     echo PHP_EOL . $person->FirstName . ' ' . $person->LastName;
-            // });
-            // echo PHP_EOL;
         }
+
         if ($page2skiptoken) {
             $page3response = $odataClient->from('People')->skiptoken($page2skiptoken)->get()->first();
             $page3results = collect($page3response->getResponseAsObject(Entity::class));
             $page3skiptoken = $page3response->getSkipToken();
             $this->assertEquals($page3results->count(), 4);
             $this->assertNull($page3skiptoken);
-            // $page3results->each(function($person) {
-            //     echo PHP_EOL . $person->FirstName . ' ' . $person->LastName;
-            // });
-            // echo PHP_EOL;
         }
     }
 

--- a/tests/ODataClientTest.php
+++ b/tests/ODataClientTest.php
@@ -48,7 +48,7 @@ class ODataClientTest extends TestCase
         $this->assertNotNull($odataClient);
         $people = $odataClient->from('People')->where('FirstName','Russell')->get();
         $this->assertTrue(is_array($people->toArray()));
-        $this->assertTrue($people->count() == 1);
+        $this->assertEquals(1, $people->count());
     }
 
     public function testODataClientFromQueryWithWhereOrWhere()
@@ -61,7 +61,7 @@ class ODataClientTest extends TestCase
                               ->get();
         // dd($people);
         $this->assertTrue(is_array($people->toArray()));
-        $this->assertTrue($people->count() == 2);
+        $this->assertEquals(2, $people->count());
     }
 
     public function testODataClientFromQueryWithWhereOrWhereArrays()
@@ -79,7 +79,7 @@ class ODataClientTest extends TestCase
                               ])
                               ->get();
         $this->assertTrue(is_array($people->toArray()));
-        $this->assertTrue($people->count() == 2);
+        $this->assertEquals(2, $people->count());
     }
 
     public function testODataClientFromQueryWithWhereOrWhereArraysAndOperators()
@@ -97,7 +97,7 @@ class ODataClientTest extends TestCase
                               ])
                               ->get();
         $this->assertTrue(is_array($people->toArray()));
-        $this->assertTrue($people->count() == 2);
+        $this->assertEquals(2, $people->count());
     }
 
     public function testODataClientFind()
@@ -105,42 +105,53 @@ class ODataClientTest extends TestCase
         $odataClient = new ODataClient($this->baseUrl);
         $this->assertNotNull($odataClient);
         $person = $odataClient->from('People')->find('russellwhyte');
-        $this->assertEquals('Russell', $person->FirstName);
+        $this->assertEquals('russellwhyte', $person->UserName);
     }
 
     public function testODataClientSkipToken()
     {
-        $odataClient = new ODataClient($this->baseUrl, function($request) {
-            $request->headers[RequestHeader::PREFER] = Constants::ODATA_MAX_PAGE_SIZE . '=' . 8;
+        $pageSize = 8;
+        $odataClient = new ODataClient($this->baseUrl, function($request) use($pageSize) {
+            $request->headers[RequestHeader::PREFER] = Constants::ODATA_MAX_PAGE_SIZE . '=' . $pageSize;
         });
         $this->assertNotNull($odataClient);
         $odataClient->setEntityReturnType(false);
         $page1response = $odataClient->from('People')->get()->first();
         $page1results = collect($page1response->getResponseAsObject(Entity::class));
-        $this->assertEquals($page1results->count(), 8);
+        $this->assertEquals($pageSize, $page1results->count());
 
         $page1skiptoken = $page1response->getSkipToken();
         if ($page1skiptoken) {
             $page2response = $odataClient->from('People')->skiptoken($page1skiptoken)->get()->first();
             $page2results = collect($page2response->getResponseAsObject(Entity::class));
             $page2skiptoken = $page2response->getSkipToken();
-            $this->assertEquals($page2results->count(), 8);
+            $this->assertEquals($pageSize, $page2results->count());
         }
 
+        $lastPageSize = 4;
         if ($page2skiptoken) {
             $page3response = $odataClient->from('People')->skiptoken($page2skiptoken)->get()->first();
             $page3results = collect($page3response->getResponseAsObject(Entity::class));
             $page3skiptoken = $page3response->getSkipToken();
-            $this->assertEquals($page3results->count(), 4);
+            $this->assertEquals($lastPageSize, $page3results->count());
             $this->assertNull($page3skiptoken);
         }
     }
 
-    public function testODataClientLazyCollection()
+    public function testODataClientCursorBeLazyCollection()
     {
-        $odataClient = new ODataClient($this->baseUrl, function($request) {
-            //$request->headers[RequestHeader::PREFER] = Constants::ODATA_MAX_PAGE_SIZE . '=' . 8;
-        });
+        $odataClient = new ODataClient($this->baseUrl);
+
+        $pageSize = 8;
+
+        $data = $odataClient->from('People')->pageSize($pageSize)->cursor();
+
+        $this->assertInstanceOf(LazyCollection::class, $data);
+    }
+
+    public function testODataClientCursorCountShouldEqualTotalEntitySetCount()
+    {
+        $odataClient = new ODataClient($this->baseUrl);
 
         $pageSize = 8;
 
@@ -148,45 +159,140 @@ class ODataClientTest extends TestCase
 
         $expectedCount = 20;
 
-        $this->assertInstanceOf(LazyCollection::class, $data);
-        $this->assertEquals($data->count(), $expectedCount);
+        $this->assertEquals($expectedCount, $data->count());
+    }
 
-        $this->assertInstanceOf(LazyCollection::class, $data);
-        $this->assertEquals(count($data->toArray()), $pageSize);
+    public function testODataClientCursorToArrayCountShouldEqualPageSize()
+    {
+        $odataClient = new ODataClient($this->baseUrl);
+
+        $pageSize = 8;
+
+        $data = $odataClient->from('People')->pageSize($pageSize)->cursor();
+
+        $this->assertEquals($pageSize, count($data->toArray()));
+    }
+
+    public function testODataClientCursorFirstShouldReturnEntityRussellWhyte()
+    {
+        $odataClient = new ODataClient($this->baseUrl);
+
+        $pageSize = 8;
+
+        $data = $odataClient->from('People')->pageSize($pageSize)->cursor();
 
         $first = $data->first();
         $this->assertInstanceOf(Entity::class, $first);
-        $this->assertEquals($first->FirstName, 'Russell');
+        $this->assertEquals('russellwhyte', $first->UserName);
+    }
+
+    public function testODataClientCursorLastShouldReturnEntityKristaKemp()
+    {
+        $odataClient = new ODataClient($this->baseUrl);
+
+        $pageSize = 8;
+
+        $data = $odataClient->from('People')->pageSize($pageSize)->cursor();
 
         $last = $data->last();
         $this->assertInstanceOf(Entity::class, $last);
-        $this->assertEquals($last->UserName, 'kristakemp');
+        $this->assertEquals('kristakemp', $last->UserName);
+    }
+
+    public function testODataClientCursorSkip1FirstShouldReturnEntityScottKetchum()
+    {
+        $odataClient = new ODataClient($this->baseUrl);
+
+        $pageSize = 8;
+
+        $data = $odataClient->from('People')->pageSize($pageSize)->cursor();
 
         $second = $data->skip(1)->first();
         $this->assertInstanceOf(Entity::class, $second);
-        $this->assertEquals($second->FirstName, 'Scott');
+        $this->assertEquals('scottketchum', $second->UserName);
+    }
+
+    public function testODataClientCursorSkip4FirstShouldReturnEntityWillieAshmore()
+    {
+        $odataClient = new ODataClient($this->baseUrl);
+
+        $pageSize = 8;
+
+        $data = $odataClient->from('People')->pageSize($pageSize)->cursor();
 
         $fifth = $data->skip(4)->first();
         $this->assertInstanceOf(Entity::class, $fifth);
-        $this->assertEquals($fifth->UserName, 'willieashmore');
+        $this->assertEquals('willieashmore', $fifth->UserName);
+    }
+
+    public function testODataClientCursorSkip7FirstShouldReturnEntityKeithPinckney()
+    {
+        $odataClient = new ODataClient($this->baseUrl);
+
+        $pageSize = 8;
+
+        $data = $odataClient->from('People')->pageSize($pageSize)->cursor();
 
         $eighth = $data->skip(7)->first();
         $this->assertInstanceOf(Entity::class, $eighth);
-        $this->assertEquals($eighth->UserName, 'keithpinckney');
+        $this->assertEquals('keithpinckney', $eighth->UserName);
+    }
+
+    public function testODataClientCursorSkip8FirstShouldReturnEntityMarshallGaray()
+    {
+        $odataClient = new ODataClient($this->baseUrl);
+
+        $pageSize = 8;
+
+        $data = $odataClient->from('People')->pageSize($pageSize)->cursor();
 
         $ninth = $data->skip(8)->first();
         $this->assertInstanceOf(Entity::class, $ninth);
-        $this->assertEquals($ninth->UserName, 'marshallgaray');
+        $this->assertEquals('marshallgaray', $ninth->UserName);
+    }
+
+    public function testODataClientCursorSkip16FirstShouldReturnEntitySandyOsbord()
+    {
+        $odataClient = new ODataClient($this->baseUrl);
+
+        $pageSize = 8;
+
+        $data = $odataClient->from('People')->pageSize($pageSize)->cursor();
 
         $seventeenth = $data->skip(16)->first();
         $this->assertInstanceOf(Entity::class, $seventeenth);
-        $this->assertEquals($seventeenth->UserName, 'sandyosborn');
+        $this->assertEquals('sandyosborn', $seventeenth->UserName);
+    }
+
+    public function testODataClientCursorSkip16LastPageShouldBe4Records()
+    {
+        $odataClient = new ODataClient($this->baseUrl);
+
+        $pageSize = 8;
+
+        $data = $odataClient->from('People')->pageSize($pageSize)->cursor();
 
         $lastPage = $data->skip(16);
-        $this->assertEquals(count($lastPage->toArray()), 4);
+        $lastPageSize = 4;
+        $this->assertEquals($lastPageSize, count($lastPage->toArray()));
+    }
 
-        $data->each(function ($person) {
+    public function testODataClientCursorIteratingShouldReturnAll20Entities()
+    {
+        $odataClient = new ODataClient($this->baseUrl);
+
+        $pageSize = 8;
+
+        $data = $odataClient->from('People')->pageSize($pageSize)->cursor();
+
+        $expectedCount = 20;
+        $counter = 0;
+
+        $data->each(function ($person) use(&$counter) {
+            $counter++;
             $this->assertInstanceOf(Entity::class, $person);
         });
+
+        $this->assertEquals($expectedCount, $counter);
     }
 }

--- a/tests/ODataClientTest.php
+++ b/tests/ODataClientTest.php
@@ -3,8 +3,11 @@
 namespace SaintSystems\OData\Tests;
 
 use PHPUnit\Framework\TestCase;
-
+use SaintSystems\OData\Entity;
 use SaintSystems\OData\ODataClient;
+use Illuminate\Support\LazyCollection;
+use SaintSystems\OData\Constants;
+use SaintSystems\OData\RequestHeader;
 
 class ODataClientTest extends TestCase
 {
@@ -12,7 +15,7 @@ class ODataClientTest extends TestCase
 
     public function setUp(): void
     {
-        $this->baseUrl = 'http://services.odata.org/V4/TripPinService';
+        $this->baseUrl = 'https://services.odata.org/V4/TripPinService';
     }
 
     public function testODataClientConstructor()
@@ -20,7 +23,7 @@ class ODataClientTest extends TestCase
         $odataClient = new ODataClient($this->baseUrl);
         $this->assertNotNull($odataClient);
         $baseUrl = $odataClient->getBaseUrl();
-        $this->assertEquals('http://services.odata.org/V4/TripPinService/', $baseUrl);
+        $this->assertEquals('https://services.odata.org/V4/TripPinService/', $baseUrl);
     }
 
     public function testODataClientEntitySetQuery()
@@ -28,7 +31,6 @@ class ODataClientTest extends TestCase
         $odataClient = new ODataClient($this->baseUrl);
         $this->assertNotNull($odataClient);
         $people = $odataClient->from('People')->get();
-        //dd($people);
         $this->assertTrue(is_array($people->toArray()));
     }
 
@@ -37,7 +39,6 @@ class ODataClientTest extends TestCase
         $odataClient = new ODataClient($this->baseUrl);
         $this->assertNotNull($odataClient);
         $people = $odataClient->select('FirstName','LastName')->from('People')->get();
-        //dd($people);
         $this->assertTrue(is_array($people->toArray()));
     }
 
@@ -46,7 +47,6 @@ class ODataClientTest extends TestCase
         $odataClient = new ODataClient($this->baseUrl);
         $this->assertNotNull($odataClient);
         $people = $odataClient->from('People')->where('FirstName','Russell')->get();
-        // dd($people);
         $this->assertTrue(is_array($people->toArray()));
         $this->assertTrue($people->count() == 1);
     }
@@ -105,7 +105,85 @@ class ODataClientTest extends TestCase
         $odataClient = new ODataClient($this->baseUrl);
         $this->assertNotNull($odataClient);
         $person = $odataClient->from('People')->find('russellwhyte');
-        //dd($person);
         $this->assertEquals('Russell', $person->FirstName);
+    }
+
+    public function testODataClientSkipToken()
+    {
+        $odataClient = new ODataClient($this->baseUrl, function($request) {
+            $request->headers[RequestHeader::PREFER] = Constants::ODATA_MAX_PAGE_SIZE . '=' . 8;
+        });
+        $this->assertNotNull($odataClient);
+        $odataClient->setEntityReturnType(false);
+        $page1response = $odataClient->from('People')->get()->first();
+        $page1results = collect($page1response->getResponseAsObject(Entity::class));
+        $this->assertEquals($page1results->count(), 8);
+        // $page1results->each(function($person) {
+        //     echo PHP_EOL . $person->FirstName . ' ' . $person->LastName;
+        // });
+        // echo PHP_EOL;
+        $page1skiptoken = $page1response->getSkipToken();
+        if ($page1skiptoken) {
+            $page2response = $odataClient->from('People')->skiptoken($page1skiptoken)->get()->first();
+            $page2results = collect($page2response->getResponseAsObject(Entity::class));
+            $page2skiptoken = $page2response->getSkipToken();
+            $this->assertEquals($page2results->count(), 8);
+            // $page2results->each(function($person) {
+            //     echo PHP_EOL . $person->FirstName . ' ' . $person->LastName;
+            // });
+            // echo PHP_EOL;
+        }
+        if ($page2skiptoken) {
+            $page3response = $odataClient->from('People')->skiptoken($page2skiptoken)->get()->first();
+            $page3results = collect($page3response->getResponseAsObject(Entity::class));
+            $page3skiptoken = $page3response->getSkipToken();
+            $this->assertEquals($page3results->count(), 4);
+            $this->assertNull($page3skiptoken);
+            // $page3results->each(function($person) {
+            //     echo PHP_EOL . $person->FirstName . ' ' . $person->LastName;
+            // });
+            // echo PHP_EOL;
+        }
+    }
+
+    public function testODataClientLazyCollection()
+    {
+        $odataClient = new ODataClient($this->baseUrl, function($request) {
+            $request->headers[RequestHeader::PREFER] = Constants::ODATA_MAX_PAGE_SIZE . '=' . 8;
+        });
+        $data = $odataClient->from('People')->cursor();
+
+        $expectedCount = 20;
+
+        $this->assertInstanceOf(LazyCollection::class, $data);
+        $this->assertEquals($data->count(), $expectedCount);
+
+        $first = $data->first();
+        $this->assertInstanceOf(Entity::class, $first);
+        $this->assertEquals($first->FirstName, 'Russell');
+
+        $last = $data->last();
+        $this->assertInstanceOf(Entity::class, $last);
+        $this->assertEquals($last->UserName, 'kristakemp');
+
+        $second = $data->skip(1)->first();
+        $this->assertInstanceOf(Entity::class, $second);
+        $this->assertEquals($second->FirstName, 'Scott');
+
+        $fifth = $data->skip(4)->first();
+        $this->assertInstanceOf(Entity::class, $fifth);
+        $this->assertEquals($fifth->UserName, 'willieashmore');
+
+        $eighth = $data->skip(7)->first();
+        $this->assertInstanceOf(Entity::class, $eighth);
+        $this->assertEquals($eighth->UserName, 'keithpinckney');
+
+        $ninth = $data->skip(8)->first();
+        $this->assertInstanceOf(Entity::class, $ninth);
+        $this->assertEquals($ninth->UserName, 'marshallgaray');
+
+        $seventeenth = $data->skip(16)->first();
+        $this->assertInstanceOf(Entity::class, $seventeenth);
+        $this->assertEquals($seventeenth->UserName, 'sandyosborn');
     }
 }

--- a/tests/ODataClientTest.php
+++ b/tests/ODataClientTest.php
@@ -139,14 +139,20 @@ class ODataClientTest extends TestCase
     public function testODataClientLazyCollection()
     {
         $odataClient = new ODataClient($this->baseUrl, function($request) {
-            $request->headers[RequestHeader::PREFER] = Constants::ODATA_MAX_PAGE_SIZE . '=' . 8;
+            //$request->headers[RequestHeader::PREFER] = Constants::ODATA_MAX_PAGE_SIZE . '=' . 8;
         });
-        $data = $odataClient->from('People')->cursor();
+
+        $pageSize = 8;
+
+        $data = $odataClient->from('People')->pageSize($pageSize)->cursor();
 
         $expectedCount = 20;
 
         $this->assertInstanceOf(LazyCollection::class, $data);
         $this->assertEquals($data->count(), $expectedCount);
+
+        $this->assertInstanceOf(LazyCollection::class, $data);
+        $this->assertEquals(count($data->toArray()), $pageSize);
 
         $first = $data->first();
         $this->assertInstanceOf(Entity::class, $first);
@@ -175,5 +181,12 @@ class ODataClientTest extends TestCase
         $seventeenth = $data->skip(16)->first();
         $this->assertInstanceOf(Entity::class, $seventeenth);
         $this->assertEquals($seventeenth->UserName, 'sandyosborn');
+
+        $lastPage = $data->skip(16);
+        $this->assertEquals(count($lastPage->toArray()), 4);
+
+        $data->each(function ($person) {
+            $this->assertInstanceOf(Entity::class, $person);
+        });
     }
 }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -113,13 +113,13 @@ class BuilderTest extends TestCase
 
         $entitySet = 'People';
 
-        //$expected = 55;
+        $expected = 20;
 
         $actual = $builder->from($entitySet)->count();
 
         $this->assertTrue(is_numeric($actual));
         $this->assertTrue($actual > 0);
-        //$this->assertEquals($expected, $actual);
+        $this->assertEquals($expected, $actual);
     }
 
     // public function testEntitySetCountWithWhere()


### PR DESCRIPTION
Fixes #22: Add new `cursor` method to `Builder` and `ODataClient` to support retrieval of @odata.nextLink and native paging support. 