### PR TITLE
composer Install guzzlehttp/guzzle 6.5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "guzzlehttp/guzzle": "^7.0",
+        "guzzlehttp/guzzle": "6.5.8",
         "nesbot/carbon": "^2.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
     },


### PR DESCRIPTION
While installing the Drupal module [odata_client](https://www.drupal.org/project/odata_client) in the latest version of Drupal 9, we encountered the following issue mentioned [here](https://github.com/saintsystems/odata-client-php/issues/108).

So, this patch is a temporary fix until the maintainer fixes it or everyone upgrades to the latest version of Drupal 10.

More info: https://www.drupal.org/project/odata_client/issues/3388005