### PR TITLE
Grammar should not convert skip token to integer

### DIFF
--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -432,7 +432,7 @@ class Grammar implements IGrammar
      */
     protected function compileSkipToken(Builder $query, $skiptoken)
     {
-        return $this->appendQueryParam('$skiptoken=') . (int) $skiptoken;
+        return $this->appendQueryParam('$skiptoken=') . $skiptoken;
     }
 
     /**


### PR DESCRIPTION
Resolves #151 