### PR TITLE
Master

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -109,6 +109,13 @@ class Builder
     public $orders;
 
     /**
+     * The custom options for the query.
+     *
+     * @var array
+     */
+    public $customOption;
+
+    /**
      * The maximum number of records to return.
      *
      * @var int
@@ -244,6 +251,19 @@ class Builder
         $this->client->setEntityKey($this->entityKey);
         return $this;
     }
+        
+    /**
+     * Add custom option to query parameters.
+     *
+     * @param string $options
+     *
+     * @return $this
+     */
+    public function addOption($option)
+    {
+        $this->customOption = $option;
+        return $this;
+    }    
 
     /**
      * Add an $expand clause to the query.

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -409,8 +409,6 @@ class Grammar implements IGrammar
 
         if (is_array($customOption)) {
             $customOption = $this->compileCompositeCustomOption($customOption);
-        } else {
-            $customOption = $this->wrapKey($customOption);
         }
 
         return $this->appendQueryParam($customOption);

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -49,6 +49,7 @@ class Grammar implements IGrammar
         'expands',
         //'search',
         'orders',
+        'customOption',
         'skip',
         'skiptoken',
         'take',
@@ -391,6 +392,47 @@ class Grammar implements IGrammar
                         : $order['sql'];
         }, $orders);
     }
+
+    /**
+     * Compile the custom options portion of the query.
+     *
+     * @param Builder $query
+     * @param string  $customOption
+     *
+     * @return string
+     */
+    protected function compileCustomOption(Builder $query, $customOption)
+    {
+        if (is_null($customOption)) {
+            return '';
+        }
+
+        if (is_array($customOption)) {
+            $customOption = $this->compileCompositeCustomOption($customOption);
+        } else {
+            $customOption = $this->wrapKey($customOption);
+        }
+
+        return $this->appendQueryParam($customOption);
+    }
+
+    /**
+     * Compile the composite Custom Options key portion of the query.
+     *
+     * @param Builder $query
+     * @param mixed   $customOption
+     *
+     * @return string
+     */
+    public function compileCompositeCustomOption($customOption)
+    {
+        $customOptions = [];
+        foreach ($customOption as $key => $value) {
+            $customOptions[] = $key . '=' . $value;
+        }
+
+        return implode(',', $customOptions);
+    }    
 
     /**
      * Compile the "$top" portions of the query.


### PR DESCRIPTION
Add custom parameters functionality.  For example in Dynamics 365 there is a need to add option cross-company=true to query from outside the user's assigned data area.   
Usage: 
$builder->addOption(['cross-company' => 'true'])->get();
or
 $builder->addOption('cross-company=true')->get();