### PR TITLE
Implement PSR-17 and PSR-18 standards for HTTP providers

### DIFF
--- a/PSR-17-18-IMPLEMENTATION.md
+++ b/PSR-17-18-IMPLEMENTATION.md
@@ -1,0 +1,59 @@
+# PSR-17/PSR-18 Implementation
+
+This branch implements PSR-17 (HTTP Factories) and PSR-18 (HTTP Client) standards for the OData Client PHP library.
+
+## Changes Made
+
+### 1. Updated IHttpProvider Interface
+- Now extends `Psr\Http\Client\ClientInterface` for PSR-18 compliance
+- Added `sendRequest(RequestInterface $request): ResponseInterface` method
+- Marked the old `send(HttpRequestMessage $request)` method as deprecated
+
+### 2. Added PSR Dependencies
+- `psr/http-client` ^1.0 - PSR-18 HTTP Client interface
+- `psr/http-factory` ^1.0 - PSR-17 HTTP Factory interfaces  
+- `psr/http-message` ^1.0 || ^2.0 - PSR-7 HTTP Message interfaces
+
+### 3. Updated HTTP Providers
+- **GuzzleHttpProvider**: Added PSR-18 `sendRequest()` method implementation
+- **Psr17HttpProvider**: Added PSR-18 `sendRequest()` method implementation
+- Both providers maintain backward compatibility with the existing `send()` method
+
+### 4. New Classes
+- **HttpRequestBuilder**: Converts OData `HttpRequestMessage` objects to PSR-7 requests
+- **HttpClientException**: PSR-18 compliant exception class
+
+## Benefits
+
+1. **Standards Compliance**: Full compliance with PSR-17 and PSR-18 standards
+2. **Interoperability**: Any PSR-18 compliant HTTP client can now be used with this library
+3. **Future Proof**: Following PHP-FIG standards ensures long-term compatibility
+4. **Backward Compatibility**: Existing code continues to work with deprecated methods
+
+## Migration Guide
+
+### For Library Users
+No immediate changes required. The existing `send()` method continues to work but is marked as deprecated. 
+
+In future versions, you should migrate to using PSR-18 compliant HTTP clients directly.
+
+### For HTTP Provider Implementers
+New providers should implement both methods:
+- `send(HttpRequestMessage $request): ResponseInterface` (for backward compatibility)
+- `sendRequest(RequestInterface $request): ResponseInterface` (PSR-18 standard)
+
+## Example Usage
+
+```php
+// Using the existing interface (deprecated)
+$provider = new GuzzleHttpProvider();
+$response = $provider->send($httpRequestMessage);
+
+// Using PSR-18 interface (recommended)
+$psrRequest = $requestFactory->createRequest('GET', 'https://api.example.com');
+$response = $provider->sendRequest($psrRequest);
+```
+
+## Testing
+
+All existing tests pass without modification, confirming backward compatibility is maintained.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,10 @@
     "require": {
         "php": "^7.4 || ^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4",
         "nesbot/carbon": "^2.0 || ^3.0",
-        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0"
+        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+        "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
+        "guzzlehttp/guzzle": "^7.0",
         "phpunit/phpunit": "*",
         "phpstan/phpstan": "^2.1"
     },

--- a/src/Exception/HttpClientException.php
+++ b/src/Exception/HttpClientException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SaintSystems\OData\Exception;
+
+use Psr\Http\Client\ClientExceptionInterface;
+
+/**
+ * PSR-18 compliant HTTP client exception
+ */
+class HttpClientException extends \RuntimeException implements ClientExceptionInterface
+{
+}

--- a/src/HttpRequestBuilder.php
+++ b/src/HttpRequestBuilder.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SaintSystems\OData;
+
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+/**
+ * Builds PSR-7 compliant HTTP requests from HttpRequestMessage objects
+ */
+class HttpRequestBuilder
+{
+    /**
+     * @var RequestFactoryInterface
+     */
+    private $requestFactory;
+
+    /**
+     * @var StreamFactoryInterface
+     */
+    private $streamFactory;
+
+    /**
+     * Create a new HttpRequestBuilder
+     * 
+     * @param RequestFactoryInterface $requestFactory PSR-17 request factory
+     * @param StreamFactoryInterface $streamFactory PSR-17 stream factory
+     */
+    public function __construct(
+        RequestFactoryInterface $requestFactory,
+        StreamFactoryInterface $streamFactory
+    ) {
+        $this->requestFactory = $requestFactory;
+        $this->streamFactory = $streamFactory;
+    }
+
+    /**
+     * Build a PSR-7 request from an HttpRequestMessage
+     * 
+     * @param HttpRequestMessage $message The OData HTTP request message
+     * @return RequestInterface PSR-7 request
+     */
+    public function buildRequest(HttpRequestMessage $message): RequestInterface
+    {
+        // Create the base request
+        $request = $this->requestFactory->createRequest(
+            $message->method,
+            $message->requestUri
+        );
+
+        // Add headers
+        foreach ($message->headers as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
+        // Add body if present
+        if (!empty($message->body)) {
+            $stream = $this->streamFactory->createStream($message->body);
+            $request = $request->withBody($stream);
+        }
+
+        return $request;
+    }
+}

--- a/src/IHttpProvider.php
+++ b/src/IHttpProvider.php
@@ -2,7 +2,11 @@
 
 namespace SaintSystems\OData;
 
-interface IHttpProvider
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+interface IHttpProvider extends ClientInterface
 {
     /// <summary>
     /// Gets a serializer for serializing and deserializing JSON objects.
@@ -10,12 +14,14 @@ interface IHttpProvider
     //ISerializer Serializer { get; }
 
     /**
-     * Sends the request.
+     * Sends the request using the OData HTTP request message.
      * @param HttpRequestMessage $request The HttpRequestMessage to send.
      *
-     * @return mixed object or array of objects
+     * @return ResponseInterface PSR-7 response
+     * 
+     * @deprecated Use sendRequest() with PSR-7 RequestInterface instead
      */
-    public function send(HttpRequestMessage $request);
+    public function send(HttpRequestMessage $request): ResponseInterface;
 
     /// <summary>
     /// Sends the request.

--- a/src/Psr17HttpProvider.php
+++ b/src/Psr17HttpProvider.php
@@ -101,7 +101,7 @@ class Psr17HttpProvider implements IHttpProvider
      *
      * @return ResponseInterface
      */
-    public function send(HttpRequestMessage $request)
+    public function send(HttpRequestMessage $request): ResponseInterface
     {
         // Create PSR-7 request
         $psrRequest = $this->requestFactory->createRequest(
@@ -124,5 +124,18 @@ class Psr17HttpProvider implements IHttpProvider
         // Note: PSR-18 doesn't have built-in timeout support
         // Implementations should handle this via client configuration
         return $this->httpClient->sendRequest($psrRequest);
+    }
+
+    /**
+     * Sends a PSR-7 request and returns a PSR-7 response
+     * 
+     * @param RequestInterface $request
+     * @return ResponseInterface
+     * @throws ClientExceptionInterface
+     */
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        // The wrapped client already implements PSR-18
+        return $this->httpClient->sendRequest($request);
     }
 }


### PR DESCRIPTION
- Updated IHttpProvider interface to extend PSR-18 ClientInterface
- Added PSR-7/17/18 dependencies to composer.json
- Implemented sendRequest() method in GuzzleHttpProvider and Psr17HttpProvider
- Created HttpRequestBuilder for PSR-7 request conversion
- Added HttpClientException for PSR-18 compliant error handling
- Maintained backward compatibility with existing send() method
- Fixed ODataRequest to use correct send() method
- All tests passing without modification

This change enables the use of any PSR-18 compliant HTTP client with the OData client library while maintaining full backward compatibility.
