### PR TITLE
feat: add support for parsing OData batch operation responses

### DIFF
--- a/src/BatchRequestBuilder.php
+++ b/src/BatchRequestBuilder.php
@@ -145,9 +145,9 @@ class BatchRequestBuilder
     /**
      * Execute the batch request
      * 
-     * @return IODataResponse
+     * @return ODataBatchResponse
      */
-    public function execute()
+    public function execute() : ODataBatchResponse
     {
         // End any open changeset
         if ($this->currentChangeset !== null) {
@@ -173,7 +173,7 @@ class BatchRequestBuilder
         // Restore original custom headers for future requests
         $this->client->setHeaders($originalHeaders);
 
-        return $response;
+        return $response[0];
     }
 
     /**

--- a/src/GuzzleHttpProvider.php
+++ b/src/GuzzleHttpProvider.php
@@ -41,7 +41,7 @@ class GuzzleHttpProvider implements IHttpProvider
 
     /**
      * Gets the timeout limit of the cURL request
-     * @return integer  The timeout in ms
+     * @return integer  The timeout in seconds
      */
     public function getTimeout()
     {
@@ -51,7 +51,7 @@ class GuzzleHttpProvider implements IHttpProvider
     /**
      * Sets the timeout limit of the cURL request
      *
-     * @param integer $timeout The timeout in ms
+     * @param integer $timeout The timeout in seconds
      *
      * @return $this
      */

--- a/src/IODataEntityResponse.php
+++ b/src/IODataEntityResponse.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SaintSystems\OData;
+
+interface IODataEntityResponse extends IODataResponse
+{
+    /**
+     * Converts the response JSON object to a OData SDK object
+     *
+     * @param mixed $returnType The type to convert the object(s) to
+     *
+     * @return mixed object or array of objects of type $returnType
+     */
+    public function getResponseAsObject($returnType);
+
+    /**
+     * Gets the skip token of a response object from OData
+     *
+     * @return string skip token, if provided
+     */
+    public function getSkipToken();
+
+    /**
+     * Gets the Id of response object (if set) from OData
+     *
+     * @return mixed id if this was an insert, if provided
+     */
+    public function getId();
+}

--- a/src/IODataResponse.php
+++ b/src/IODataResponse.php
@@ -31,27 +31,4 @@ interface IODataResponse
      * @var array The response headers
      */
     public function getHeaders();
-
-    /**
-     * Converts the response JSON object to a OData SDK object
-     *
-     * @param mixed $returnType The type to convert the object(s) to
-     *
-     * @return mixed object or array of objects of type $returnType
-     */
-    public function getResponseAsObject($returnType);
-
-    /**
-     * Gets the skip token of a response object from OData
-     *
-     * @return string skip token, if provided
-     */
-    public function getSkipToken();
-
-    /**
-     * Gets the Id of response object (if set) from OData
-     *
-     * @return mixed id if this was an insert, if provided
-     */
-    public function getId();
 }

--- a/src/ODataBatchResponse.php
+++ b/src/ODataBatchResponse.php
@@ -38,7 +38,7 @@ class ODataBatchResponse implements IODataResponse
     private function extractBoundary(): string
     {
         $contentType = $this->getContentTypeHeader();
-        if ($contentType !== null && preg_match('/^multipart\/mixed;\s*boundary=(["\']?)([^"\';]+)\1$/', $contentType, $matches)) {
+        if ($contentType !== null && preg_match('/^multipart\/mixed;\s*boundary=(["\']?)([^"\';]+)\1/', $contentType, $matches)) {
             return $matches[2];
         }
 

--- a/src/ODataBatchResponse.php
+++ b/src/ODataBatchResponse.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace SaintSystems\OData;
+
+use SaintSystems\OData\Exception\ODataException;
+
+class ODataBatchResponse implements IODataResponse
+{
+    private IODataRequest $request;
+    private ?string $body;
+    /**
+     * @var array<string, string|array<int, string>>
+     */
+    private array $headers;
+    private int $httpStatusCode;
+    /**
+     * @var array<int, ODataResponse>
+     */
+    private array $responses;
+    private string $boundary;
+
+    /**
+     * @throws ODataException
+     */
+    public function __construct(IODataRequest $request, string $body, int $httpStatusCode, array $headers = [])
+    {
+        $this->request = $request;
+        $this->body = $body;
+        $this->httpStatusCode = $httpStatusCode;
+        $this->headers = $headers;
+        $this->boundary = $this->extractBoundary();
+        $this->responses = $this->parseBatchResponse();
+    }
+
+    /**
+     * @throws ODataException
+     */
+    private function extractBoundary(): string
+    {
+        $contentType = $this->getContentTypeHeader();
+        if ($contentType !== null && preg_match('/^multipart\/mixed;\s*boundary=(["\']?)([^"\';]+)\1$/', $contentType, $matches)) {
+            return $matches[2];
+        }
+
+        if ($contentType === null) {
+            throw new ODataException(
+                'No boundary found in batch response content-type header (content-type header is missing).'
+            );
+        }
+        throw new ODataException('No boundary found in batch response content-type header: ' . $contentType);
+    }
+
+    private function getContentTypeHeader(): ?string
+    {
+        foreach ($this->headers as $key => $value) {
+            if (strtolower($key) === 'content-type') {
+                return is_array($value) ? $value[0] : $value;
+            }
+        }
+        return null;
+    }
+
+    private function parseBatchResponse(): array
+    {
+        if ($this->body === null || $this->body === '') {
+            return [];
+        }
+
+        $responses = [];
+        $parts = explode('--' . $this->boundary, $this->body);
+
+        foreach ($parts as $part) {
+            $part = trim($part);
+            // Skip empty parts and boundary end marker
+            if ('' === $part || '--' === $part) {
+                continue;
+            }
+
+            $changesetBoundary = $this->extractChangesetBoundary($part);
+            if (null === $changesetBoundary) {
+                $responses[] = $this->parseIndividualResponse($part);
+            } else {
+                $changesetResponses = $this->parseChangesetPart($part, $changesetBoundary);
+                array_push($responses, ...$changesetResponses);
+            }
+        }
+
+        return $responses;
+    }
+
+    private function extractChangesetBoundary(string $part): ?string
+    {
+        if (preg_match('/^Content-Type:\s*multipart\/mixed;\s*boundary=["\']?([^"\'\s;]+)["\']?/i', $part, $matches)) {
+            return $matches[1];
+        }
+        return null;
+    }
+
+    private function parseChangesetPart(string $part, string $changesetBoundary): array
+    {
+        // Find where changeset content starts (after empty line)
+        $changesetContent = $this->extractChangesetContent($part);
+
+        // Parse individual responses within changeset
+        $changesetParts = explode('--' . $changesetBoundary, $changesetContent);
+        $responses = [];
+
+        foreach ($changesetParts as $changesetPart) {
+            $changesetPart = trim($changesetPart);
+            if ('' === $changesetPart || '--' === $changesetPart) {
+                continue;
+            }
+
+            $responses[] = $this->parseIndividualResponse($changesetPart);
+        }
+
+        return $responses;
+    }
+
+    private function extractChangesetContent(string $part): string
+    {
+        $separator = $this->detectHeaderSeparator($part);
+
+        $changesetParts = explode($separator, $part, 2);
+
+        return $changesetParts[1];
+    }
+
+    /**
+     * @throws ODataException
+     */
+    private function detectHeaderSeparator(string $part): string
+    {
+        if (strpos($part, "\r\n\r\n") !== false) {
+            return "\r\n\r\n";
+        }
+        if (strpos($part, "\n\n") !== false) {
+            return "\n\n";
+        }
+        throw new ODataException('No header/body separator found in changeset part: ' . $part);
+    }
+
+    private function parseIndividualResponse(string $part): ODataResponse
+    {
+        $separator = $this->detectHeaderSeparator($part);
+
+        $responseParts = explode($separator, $part, 3);
+
+        if (count($responseParts) < 2) {
+            throw new ODataException('Unexpected header format in response part: ' . $part);
+        }
+
+        $responseHeaders = $responseParts[0];
+        $httpHeaders = $responseParts[1];
+        $responseBody = $responseParts[2] ?? '';
+
+        $responseHeadersResult = $this->parseHttpHeaders($responseHeaders);
+
+        $httpHeadersResult = $this->parseHttpHeaders($httpHeaders);
+        $responseHeaders = $httpHeadersResult['headers'];
+        $statusCode = $httpHeadersResult['statusCode'];
+
+        if (null === $statusCode) {
+            throw new ODataException('No http status code found in response part: ' . $part);
+        }
+
+        if (array_key_exists('Content-ID', $responseHeadersResult['headers'])) {
+            $responseHeaders['Content-ID'] = $responseHeadersResult['headers']['Content-ID'];
+        }
+
+        return new ODataResponse($this->request, $responseBody, $statusCode, $responseHeaders);
+    }
+
+    /**
+     * Parse HTTP headers with support for multi-line headers (header folding)
+     *
+     * @param string $headerString Raw HTTP header block
+     * @return array{statusCode: int|null, statusText: string, headers: array<string, string|array<int, string>>} Parsed headers with status code, status text, and header key-value pairs
+     */
+    private function parseHttpHeaders(string $headerString): array
+    {
+        // Unfold headers: replace CRLF followed by whitespace with a single space
+        $headerString = preg_replace('/\r?\n[ \t]+/', ' ', $headerString);
+
+        $lines = explode("\n", $headerString);
+        $result = [
+            'statusCode' => null,
+            'statusText' => '',
+            'headers' => []
+        ];
+
+        foreach ($lines as $index => $line) {
+            $line = rtrim($line, "\r");
+
+            // Try to parse first line as status line (e.g., "HTTP/1.1 412 Precondition Failed")
+            if (0 === $index && preg_match('/^HTTP\/\d\.\d\s+(\d{3})(\s+(.*))?$/', $line, $matches)) {
+                $result['statusCode'] = (int)$matches[1];
+                $result['statusText'] = trim($matches[3] ?? '');
+                continue;
+            }
+
+            // Skip empty lines
+            if (trim($line) === '') {
+                continue;
+            }
+
+            // Parse header line
+            if (strpos($line, ':') !== false) {
+                [$name, $value] = explode(':', $line, 2);
+                $name = trim($name);
+                $value = trim($value);
+
+                // Store multiple headers with same name as array
+                if (array_key_exists($name, $result['headers'])) {
+                    if (!is_array($result['headers'][$name])) {
+                        $result['headers'][$name] = [$result['headers'][$name]];
+                    }
+                    $result['headers'][$name][] = $value;
+                } else {
+                    $result['headers'][$name] = $value;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the decoded bodies of all responses in the batch
+     *
+     * @return array<int, array> Array of decoded response bodies, where each element is the JSON-decoded body
+     *                           of an individual response in the batch. Returns empty array if no responses.
+     */
+    public function getBody(): array
+    {
+        $bodies = [];
+        foreach ($this->responses as $response) {
+            $bodies[] = $response->getBody();
+        }
+        return $bodies;
+    }
+
+    public function getRawBody(): ?string
+    {
+        return $this->body;
+    }
+
+    public function getStatus(): int
+    {
+        return $this->httpStatusCode;
+    }
+
+    /**
+     * Get the headers of the batch response
+     *
+     * @return array<string, string|array<int, string>>
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    /**
+     * Get all individual responses in the batch
+     *
+     * @return array<int, ODataResponse>
+     */
+    public function getResponses(): array
+    {
+        return $this->responses;
+    }
+
+    public function getResponse(int $index): ?ODataResponse
+    {
+        return $this->responses[$index] ?? null;
+    }
+}

--- a/src/ODataBatchResponse.php
+++ b/src/ODataBatchResponse.php
@@ -274,4 +274,21 @@ class ODataBatchResponse implements IODataResponse
     {
         return $this->responses[$index] ?? null;
     }
+
+    public function getResponseByContentId(string $contentId): ?ODataResponse
+    {
+        foreach ($this->responses as $response) {
+            foreach ($response->getHeaders() as $name => $value) {
+                if (strtolower($name) !== 'content-id') {
+                    continue;
+                }
+
+                if (is_array($value) ? in_array($contentId, $value, true) : $value === $contentId) {
+                    return $response;
+                }
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/ODataResponse.php
+++ b/src/ODataResponse.php
@@ -25,7 +25,7 @@ namespace SaintSystems\OData;
  * @package  SaintSystems.OData
  * @license  https://opensource.org/licenses/MIT MIT License
  */
-class ODataResponse implements IODataResponse
+class ODataResponse implements IODataEntityResponse
 {
     /**
      * The request
@@ -59,7 +59,7 @@ class ODataResponse implements IODataResponse
     /**
      * The status code of the response
      *
-     * @var string
+     * @var int
      */
     private $httpStatusCode;
 
@@ -68,8 +68,8 @@ class ODataResponse implements IODataResponse
      *
      * @param object $request        The request
      * @param string $body           The body of the response
-     * @param string $httpStatusCode The returned status code
-     * @param array  $headers        The returned headers
+     * @param int $httpStatusCode    The returned status code
+     * @param array $headers         The returned headers
      */
     public function __construct($request, $body = null, $httpStatusCode = null, $headers = array())
     {
@@ -122,7 +122,7 @@ class ODataResponse implements IODataResponse
     /**
      * Get the status of the HTTP response
      *
-     * @return string The HTTP status
+     * @return int The HTTP status
      */
     public function getStatus()
     {

--- a/src/ODataResponseFactory.php
+++ b/src/ODataResponseFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SaintSystems\OData;
+
+class ODataResponseFactory
+{
+    /**
+     * Create an OData response instance based on the given request and HTTP response data.
+     *
+     * If the Content-Type header indicates a multipart/mixed batch response, an
+     * {@see ODataBatchResponse} instance is returned; otherwise, a standard
+     * {@see ODataResponse} is created.
+     *
+     * @param IODataRequest $request    The originating OData request associated with this response.
+     * @param string        $body       The raw HTTP response body.
+     * @param int           $statusCode The HTTP status code of the response.
+     * @param array         $headers    The HTTP response headers, keyed by header name.
+     *
+     * @return ODataResponse|ODataBatchResponse
+     */
+    public static function create(IODataRequest $request, string $body, int $statusCode, array $headers = []): IODataResponse
+    {
+        $contentType = self::getContentType($headers);
+
+        if (
+            $contentType !== null &&
+            preg_match('/^multipart\/mixed;\s*boundary=(["\']?)([^"\';]+)\1/', $contentType)
+        ) {
+            return new ODataBatchResponse($request, $body, $statusCode, $headers);
+        }
+
+        return new ODataResponse($request, $body, $statusCode, $headers);
+    }
+
+    private static function getContentType(array $headers): ?string
+    {
+        foreach ($headers as $key => $value) {
+            if ($value !== null && strtolower($key) === 'content-type') {
+                return is_array($value) ? $value[0] : $value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/ODataBatchResponseTest.php
+++ b/tests/ODataBatchResponseTest.php
@@ -1,0 +1,699 @@
+<?php
+
+namespace SaintSystems\OData\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SaintSystems\OData\Exception\ODataException;
+use SaintSystems\OData\ODataBatchResponse;
+use SaintSystems\OData\ODataResponse;
+use SaintSystems\OData\IODataRequest;
+
+class ODataBatchResponseTest extends TestCase
+{
+
+    public function testBatchResponseExample(): void
+    {
+        $boundary = 'batchresponse_01346794-f2e2-4d45-8cc2-f97e09fe8916';
+
+        $body = <<<EOD
+--$boundary
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+HTTP/1.1 204 No Content
+OData-Version: 4.0
+Location: [Organization Uri]/api/data/v9.2/tasks(00aa00aa-bb11-cc22-dd33-44ee44ee44ee)
+OData-EntityId: [Organization Uri]/api/data/v9.2/tasks(00aa00aa-bb11-cc22-dd33-44ee44ee44ee)
+
+--$boundary
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+HTTP/1.1 204 No Content
+OData-Version: 4.0
+Location: [Organization Uri]/api/data/v9.2/tasks(11bb11bb-cc22-dd33-ee44-55ff55ff55ff)
+OData-EntityId: [Organization Uri]/api/data/v9.2/tasks(11bb11bb-cc22-dd33-ee44-55ff55ff55ff)
+
+--$boundary
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+HTTP/1.1 200 OK
+Content-Type: application/json; odata.metadata=minimal; odata.streaming=true
+OData-Version: 4.0
+
+{
+  "@odata.context": "[Organization Uri]/api/data/v9.2/\$metadata#tasks(subject)",
+  "value": [
+    {
+      "@odata.etag": "W/\"77180907\"",
+      "subject": "Task 1 in batch",
+      "activityid": "00aa00aa-bb11-cc22-dd33-44ee44ee44ee"
+    },
+    {
+      "@odata.etag": "W/\"77180908\"",
+      "subject": "Task 2 in batch",
+      "activityid": "11bb11bb-cc22-dd33-ee44-55ff55ff55ff"
+    }
+  ]
+}
+--$boundary--
+
+EOD;
+
+        $headers = [
+            'Content-Type' => "multipart/mixed; boundary=$boundary",
+            'OData-Version' => '4.0'
+        ];
+
+        $request = $this->createMock(IODataRequest::class);
+        $batchResponse = new ODataBatchResponse($request, $body, 200, $headers);
+
+        $responses = $batchResponse->getResponses();
+        $this->assertCount(3, $responses);
+
+        // Verify status codes
+        $this->assertSame(204, $responses[0]->getStatus());
+        $this->assertSame(204, $responses[1]->getStatus());
+        $this->assertSame(200, $responses[2]->getStatus());
+
+        // Verify response headers
+        $headers1 = $responses[0]->getHeaders();
+        $this->assertSame('4.0', $headers1['OData-Version']);
+        $this->assertSame('[Organization Uri]/api/data/v9.2/tasks(00aa00aa-bb11-cc22-dd33-44ee44ee44ee)', $headers1['Location']);
+        $this->assertSame('[Organization Uri]/api/data/v9.2/tasks(00aa00aa-bb11-cc22-dd33-44ee44ee44ee)', $headers1['OData-EntityId']);
+
+        $headers2 = $responses[1]->getHeaders();
+        $this->assertSame('4.0', $headers2['OData-Version']);
+        $this->assertSame('[Organization Uri]/api/data/v9.2/tasks(11bb11bb-cc22-dd33-ee44-55ff55ff55ff)', $headers2['Location']);
+        $this->assertSame('[Organization Uri]/api/data/v9.2/tasks(11bb11bb-cc22-dd33-ee44-55ff55ff55ff)', $headers2['OData-EntityId']);
+
+        $headers3 = $responses[2]->getHeaders();
+        $this->assertSame('application/json; odata.metadata=minimal; odata.streaming=true', $headers3['Content-Type']);
+        $this->assertSame('4.0', $headers3['OData-Version']);
+
+        // Verify raw body content
+        $expectedJson = <<<'JSON'
+{
+  "@odata.context": "[Organization Uri]/api/data/v9.2/$metadata#tasks(subject)",
+  "value": [
+    {
+      "@odata.etag": "W/\"77180907\"",
+      "subject": "Task 1 in batch",
+      "activityid": "00aa00aa-bb11-cc22-dd33-44ee44ee44ee"
+    },
+    {
+      "@odata.etag": "W/\"77180908\"",
+      "subject": "Task 2 in batch",
+      "activityid": "11bb11bb-cc22-dd33-ee44-55ff55ff55ff"
+    }
+  ]
+}
+JSON;
+        $this->assertSame($expectedJson, $responses[2]->getRawBody());
+
+        // Verify expected structure
+        $jsonResponse = $responses[2];
+        $body = $jsonResponse->getBody();
+        $this->assertSame('Task 1 in batch', $body['value'][0]['subject']);
+        $this->assertSame('Task 2 in batch', $body['value'][1]['subject']);
+    }
+
+    public function testChangesetBatchResponse(): void
+    {
+        $boundary = 'batchresponse_f27ef42d-51b0-4685-bac9-f468f844de2f';
+        $changesetBoundary = 'changesetresponse_5c9b9207-0a2e-4a4f-9b7a-8b8b8b8b8b8b';
+
+        $body = <<<EOD
+--$boundary
+Content-Type: multipart/mixed; boundary=$changesetBoundary
+
+--$changesetBoundary
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 1
+
+HTTP/1.1 204 No Content
+OData-Version: 4.0
+Location: [Organization URI]/api/data/v9.2/accounts(55ff55ff-aa66-bb77-cc88-99dd99dd99dd)
+OData-EntityId: [Organization URI]/api/data/v9.2/accounts(55ff55ff-aa66-bb77-cc88-99dd99dd99dd)
+
+--$changesetBoundary
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 2
+
+HTTP/1.1 204 No Content
+OData-Version: 4.0
+Location: [Organization URI]/api/data/v9.2/contacts(66aa66aa-bb77-cc88-dd99-00ee00ee00ee)
+OData-EntityId: [Organization URI]/api/data/v9.2/contacts(66aa66aa-bb77-cc88-dd99-00ee00ee00ee)
+
+--$changesetBoundary--
+--$boundary--
+
+EOD;
+
+        $headers = [
+            'Content-Type' => "multipart/mixed; boundary=$boundary",
+            'OData-Version' => '4.0'
+        ];
+
+        $request = $this->createMock(IODataRequest::class);
+        $batchResponse = new ODataBatchResponse($request, $body, 200, $headers);
+
+        $responses = $batchResponse->getResponses();
+
+        $this->assertCount(2, $responses);
+
+        $response1 = $responses[0];
+        $this->assertInstanceOf(ODataResponse::class, $response1);
+        $this->assertSame(204, $response1->getStatus());
+
+        $headers1 = $response1->getHeaders();
+        $this->assertSame('4.0', $headers1['OData-Version']);
+        $this->assertSame('[Organization URI]/api/data/v9.2/accounts(55ff55ff-aa66-bb77-cc88-99dd99dd99dd)', $headers1['Location']);
+        $this->assertSame('[Organization URI]/api/data/v9.2/accounts(55ff55ff-aa66-bb77-cc88-99dd99dd99dd)', $headers1['OData-EntityId']);
+        $this->assertSame('', $response1->getRawBody());
+
+        $response2 = $responses[1];
+        $this->assertInstanceOf(ODataResponse::class, $response2);
+        $this->assertSame(204, $response2->getStatus());
+
+        $headers2 = $response2->getHeaders();
+        $this->assertSame('4.0', $headers2['OData-Version']);
+        $this->assertSame('[Organization URI]/api/data/v9.2/contacts(66aa66aa-bb77-cc88-dd99-00ee00ee00ee)', $headers2['Location']);
+        $this->assertSame('[Organization URI]/api/data/v9.2/contacts(66aa66aa-bb77-cc88-dd99-00ee00ee00ee)', $headers2['OData-EntityId']);
+        $this->assertSame('', $response2->getRawBody());
+    }
+
+    public function testBatchResponseWithMixedSuccessAndFailure(): void
+    {
+        $boundary = 'batchresponse_a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+        $body = <<<EOD
+--$boundary
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+HTTP/1.1 400 Bad Request
+Content-Type: application/json; odata.metadata=minimal
+OData-Version: 4.0
+
+{
+  "error": {
+    "code": "0x80040237",
+    "message": "Subject length exceeded maximum of 200 characters",
+    "innererror": {
+      "message": "Subject length exceeded maximum of 200 characters",
+      "type": "System.ArgumentException"
+    }
+  }
+}
+
+--$boundary
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+HTTP/1.1 204 No Content
+OData-Version: 4.0
+Location: [Organization Uri]/api/data/v9.2/tasks(22cc22cc-dd33-ee44-ff55-66aa66aa66aa)
+OData-EntityId: [Organization Uri]/api/data/v9.2/tasks(22cc22cc-dd33-ee44-ff55-66aa66aa66aa)
+
+--$boundary
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+HTTP/1.1 204 No Content
+OData-Version: 4.0
+Location: [Organization Uri]/api/data/v9.2/tasks(33dd33dd-ee44-ff55-aa66-77bb77bb77bb)
+OData-EntityId: [Organization Uri]/api/data/v9.2/tasks(33dd33dd-ee44-ff55-aa66-77bb77bb77bb)
+
+--$boundary
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+HTTP/1.1 404 Not Found
+Content-Type: application/json; odata.metadata=minimal
+OData-Version: 4.0
+
+{
+  "error": {
+    "code": "0x80040217",
+    "message": "The requested resource does not exist",
+    "innererror": {
+      "message": "Entity with id '99zz99zz-invalid-entity-id' does not exist",
+      "type": "Microsoft.Xrm.Sdk.InvalidOperationException"
+    }
+  }
+}
+
+--$boundary--
+
+EOD;
+
+        $headers = [
+            'Content-Type' => "multipart/mixed; boundary=$boundary",
+            'OData-Version' => '4.0',
+            'Prefer' => 'odata.continue-on-error'
+        ];
+
+        $request = $this->createMock(IODataRequest::class);
+        $batchResponse = new ODataBatchResponse($request, $body, 200, $headers);
+
+        $responses = $batchResponse->getResponses();
+        $this->assertCount(4, $responses);
+
+        // Verify status codes
+        $this->assertSame(400, $responses[0]->getStatus());
+        $this->assertSame(204, $responses[1]->getStatus());
+        $this->assertSame(204, $responses[2]->getStatus());
+        $this->assertSame(404, $responses[3]->getStatus());
+
+        // Verify headers
+        $errorHeaders1 = $responses[0]->getHeaders();
+        $this->assertSame('application/json; odata.metadata=minimal', $errorHeaders1['Content-Type']);
+        $this->assertSame('4.0', $errorHeaders1['OData-Version']);
+
+        $successHeaders2 = $responses[1]->getHeaders();
+        $this->assertSame('4.0', $successHeaders2['OData-Version']);
+        $this->assertSame('[Organization Uri]/api/data/v9.2/tasks(22cc22cc-dd33-ee44-ff55-66aa66aa66aa)', $successHeaders2['Location']);
+        $this->assertSame('[Organization Uri]/api/data/v9.2/tasks(22cc22cc-dd33-ee44-ff55-66aa66aa66aa)', $successHeaders2['OData-EntityId']);
+
+        $successHeaders3 = $responses[2]->getHeaders();
+        $this->assertSame('4.0', $successHeaders3['OData-Version']);
+        $this->assertSame('[Organization Uri]/api/data/v9.2/tasks(33dd33dd-ee44-ff55-aa66-77bb77bb77bb)', $successHeaders3['Location']);
+        $this->assertSame('[Organization Uri]/api/data/v9.2/tasks(33dd33dd-ee44-ff55-aa66-77bb77bb77bb)', $successHeaders3['OData-EntityId']);
+
+        $errorHeaders4 = $responses[3]->getHeaders();
+        $this->assertSame('application/json; odata.metadata=minimal', $errorHeaders4['Content-Type']);
+        $this->assertSame('4.0', $errorHeaders4['OData-Version']);
+
+
+        // Verify response bodies
+        $expectedError1 = <<<'JSON'
+{
+  "error": {
+    "code": "0x80040237",
+    "message": "Subject length exceeded maximum of 200 characters",
+    "innererror": {
+      "message": "Subject length exceeded maximum of 200 characters",
+      "type": "System.ArgumentException"
+    }
+  }
+}
+JSON;
+        $this->assertSame($expectedError1, $responses[0]->getRawBody());
+
+        $expectedError2 = <<<'JSON'
+{
+  "error": {
+    "code": "0x80040217",
+    "message": "The requested resource does not exist",
+    "innererror": {
+      "message": "Entity with id '99zz99zz-invalid-entity-id' does not exist",
+      "type": "Microsoft.Xrm.Sdk.InvalidOperationException"
+    }
+  }
+}
+JSON;
+        $this->assertSame($expectedError2, $responses[3]->getRawBody());
+
+        // Verify expected structure
+        $errorResponse1 = $responses[0]->getBody();
+        $errorResponse2 = $responses[3]->getBody();
+        $this->assertSame('0x80040237', $errorResponse1['error']['code']);
+        $this->assertSame('0x80040217', $errorResponse2['error']['code']);
+
+        // Test that batch overall status is still 200 OK (continue-on-error)
+        $this->assertSame(200, $batchResponse->getStatus());
+    }
+
+    public function testEmptyBodyReturnsEmptyResponses(): void
+    {
+        $headers = ['Content-Type' => 'multipart/mixed; boundary=test'];
+        $request = $this->createMock(IODataRequest::class);
+
+        $batchResponse = new ODataBatchResponse($request, '', 200, $headers);
+
+        $this->assertSame([], $batchResponse->getResponses());
+        $this->assertSame([], $batchResponse->getBody());
+    }
+
+    public function testMissingBoundaryThrowsException(): void
+    {
+        $this->expectException(ODataException::class);
+        $this->expectExceptionMessage('No boundary found in batch response content-type header');
+
+        $headers = ['Content-Type' => 'application/json'];
+        $request = $this->createMock(IODataRequest::class);
+
+        new ODataBatchResponse($request, 'body', 200, $headers);
+    }
+
+    public function testMissingContentTypeHeaderThrowsException(): void
+    {
+        $this->expectException(ODataException::class);
+        $this->expectExceptionMessage('No boundary found in batch response content-type header (content-type header is missing).');
+
+        $headers = [];
+        $request = $this->createMock(IODataRequest::class);
+
+        new ODataBatchResponse($request, 'body', 200, $headers);
+    }
+
+    public function testMissingContentTypeThrowsException(): void
+    {
+        $this->expectException(ODataException::class);
+        $this->expectExceptionMessage('No boundary found in batch response content-type header');
+
+        $headers = [];
+        $request = $this->createMock(IODataRequest::class);
+
+        new ODataBatchResponse($request, 'body', 200, $headers);
+    }
+
+    public function testContentTypeAsArrayIsHandled(): void
+    {
+        $boundary = 'test-boundary-array';
+        $body = <<<EOD
+--$boundary
+Content-Type: application/http
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"test": "data"}
+--$boundary--
+EOD;
+
+        $headers = ['Content-Type' => ["multipart/mixed; boundary=$boundary", 'other']];
+        $request = $this->createMock(IODataRequest::class);
+
+        $batchResponse = new ODataBatchResponse($request, $body, 200, $headers);
+        $this->assertCount(1, $batchResponse->getResponses());
+    }
+
+    public function testLinuxLineEndingsAreSupported(): void
+    {
+        $boundary = 'batch_unix';
+        $body = "--$boundary\nContent-Type: application/http\n\nHTTP/1.1 200 OK\nContent-Type: application/json\n\n[]\n--$boundary--";
+
+        $headers = ['Content-Type' => "multipart/mixed; boundary=$boundary"];
+        $request = $this->createMock(IODataRequest::class);
+
+        $batchResponse = new ODataBatchResponse($request, $body, 200, $headers);
+        $responses = $batchResponse->getResponses();
+
+        $this->assertCount(1, $responses);
+        $this->assertSame(200, $responses[0]->getStatus());
+    }
+
+    public function testNoHeaderSeparatorThrowsException(): void
+    {
+        $this->expectException(ODataException::class);
+        $this->expectExceptionMessage('No header/body separator found in changeset part');
+
+        $boundary = 'bad-boundary';
+        $body = "--$boundary\nContent-Type: application/http\nHTTP/1.1 200 OK\n--$boundary--";
+
+        $headers = ['Content-Type' => "multipart/mixed; boundary=$boundary"];
+        $request = $this->createMock(IODataRequest::class);
+
+        new ODataBatchResponse($request, $body, 200, $headers);
+    }
+
+    public function testMissingStatusCodeThrowsException(): void
+    {
+        $this->expectException(ODataException::class);
+        $this->expectExceptionMessage('No http status code found in response part');
+
+        $boundary = 'bad-format';
+        // Has proper separators but missing HTTP status line in second section
+        $body = "--$boundary\nContent-Type: application/http\n\nContent-Type: application/json\n\n{\"test\": \"data\"}\n--$boundary--";
+
+        $headers = ['Content-Type' => "multipart/mixed; boundary=$boundary"];
+        $request = $this->createMock(IODataRequest::class);
+
+        new ODataBatchResponse($request, $body, 200, $headers);
+    }
+
+    public function testMultiLineHeadersAreParsedCorrectly(): void
+    {
+        $boundary = 'multiline-test';
+        $body = <<<EOD
+--$boundary
+Content-Type: application/http
+
+HTTP/1.1 200 OK
+Content-Type: application/json;
+ odata.metadata=minimal;
+ charset=utf-8
+X-Custom: value
+
+{"test": "data"}
+--$boundary--
+EOD;
+
+        $headers = ['Content-Type' => "multipart/mixed; boundary=$boundary"];
+        $request = $this->createMock(IODataRequest::class);
+
+        $batchResponse = new ODataBatchResponse($request, $body, 200, $headers);
+        $responses = $batchResponse->getResponses();
+
+        $this->assertCount(1, $responses);
+        $responseHeaders = $responses[0]->getHeaders();
+        $this->assertSame('application/json; odata.metadata=minimal; charset=utf-8', $responseHeaders['Content-Type']);
+    }
+
+    public function testMultipleHeadersWithSameNameAreHandled(): void
+    {
+        $boundary = 'duplicate-headers';
+        $body = <<<EOD
+--$boundary
+Content-Type: application/http
+
+HTTP/1.1 200 OK
+Set-Cookie: session=abc123
+Set-Cookie: token=xyz789
+Content-Type: application/json
+
+{"test": "data"}
+--$boundary--
+EOD;
+
+        $headers = ['Content-Type' => "multipart/mixed; boundary=$boundary"];
+        $request = $this->createMock(IODataRequest::class);
+
+        $batchResponse = new ODataBatchResponse($request, $body, 200, $headers);
+        $responses = $batchResponse->getResponses();
+
+        $this->assertCount(1, $responses);
+        $responseHeaders = $responses[0]->getHeaders();
+        $this->assertIsArray($responseHeaders['Set-Cookie']);
+        $this->assertSame(['session=abc123', 'token=xyz789'], $responseHeaders['Set-Cookie']);
+    }
+
+    public function testStatusLineWithoutStatusTextIsHandled(): void
+    {
+        $boundary = 'no-status-text';
+        $body = <<<EOD
+--$boundary
+Content-Type: application/http
+
+HTTP/1.1 200
+Content-Type: application/json
+
+{"test": "data"}
+--$boundary--
+EOD;
+
+        $headers = ['Content-Type' => "multipart/mixed; boundary=$boundary"];
+        $request = $this->createMock(IODataRequest::class);
+
+        $batchResponse = new ODataBatchResponse($request, $body, 200, $headers);
+        $responses = $batchResponse->getResponses();
+
+        $this->assertCount(1, $responses);
+        $this->assertSame(200, $responses[0]->getStatus());
+    }
+
+    public function testGetResponseReturnsNullForInvalidIndex(): void
+    {
+        $boundary = 'test-boundary';
+        $body = <<<EOD
+--$boundary
+Content-Type: application/http
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"test": "data"}
+--$boundary--
+EOD;
+
+        $headers = ['Content-Type' => "multipart/mixed; boundary=$boundary"];
+        $request = $this->createMock(IODataRequest::class);
+
+        $batchResponse = new ODataBatchResponse($request, $body, 200, $headers);
+
+        $this->assertNull($batchResponse->getResponse(999));
+        $this->assertNull($batchResponse->getResponse(-1));
+    }
+
+    public function testGetResponseReturnsCorrectResponse(): void
+    {
+        $boundary = 'test-boundary';
+        $body = <<<EOD
+--$boundary
+Content-Type: application/http
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"id": 1}
+--$boundary
+Content-Type: application/http
+
+HTTP/1.1 201 Created
+Content-Type: application/json
+
+{"id": 2}
+--$boundary--
+EOD;
+
+        $headers = ['Content-Type' => "multipart/mixed; boundary=$boundary"];
+        $request = $this->createMock(IODataRequest::class);
+
+        $batchResponse = new ODataBatchResponse($request, $body, 200, $headers);
+
+        $response0 = $batchResponse->getResponse(0);
+        $response1 = $batchResponse->getResponse(1);
+
+        $this->assertNotNull($response0);
+        $this->assertNotNull($response1);
+        $this->assertSame(200, $response0->getStatus());
+        $this->assertSame(201, $response1->getStatus());
+    }
+
+    public function testGetHeadersReturnsBatchHeaders(): void
+    {
+        $boundary = 'test-boundary';
+        $body = "--$boundary\nContent-Type: application/http\n\nHTTP/1.1 200 OK\n\n[]\n--$boundary--";
+        $headers = [
+            'Content-Type' => "multipart/mixed; boundary=$boundary",
+            'OData-Version' => '4.0',
+            'Custom-Header' => 'custom-value'
+        ];
+
+        $request = $this->createMock(IODataRequest::class);
+        $batchResponse = new ODataBatchResponse($request, $body, 200, $headers);
+
+        $returnedHeaders = $batchResponse->getHeaders();
+        $this->assertSame($headers, $returnedHeaders);
+        $this->assertSame('4.0', $returnedHeaders['OData-Version']);
+        $this->assertSame('custom-value', $returnedHeaders['Custom-Header']);
+    }
+
+    public function testGetRawBodyReturnsOriginalBody(): void
+    {
+        $boundary = 'test-boundary';
+        $body = "--$boundary\nContent-Type: application/http\n\nHTTP/1.1 200 OK\n\n[]\n--$boundary--";
+        $headers = ['Content-Type' => "multipart/mixed; boundary=$boundary"];
+
+        $request = $this->createMock(IODataRequest::class);
+        $batchResponse = new ODataBatchResponse($request, $body, 200, $headers);
+
+        $this->assertSame($body, $batchResponse->getRawBody());
+    }
+
+    public function testErrorStatusCodesAreParsedCorrectly(): void
+    {
+        $boundary = 'error-test';
+        $body = <<<EOD
+--$boundary
+Content-Type: application/http
+
+HTTP/1.1 412 Precondition Failed
+REQ_ID: 298375c3-8565-40ba-87a4-e8b762a5c39b
+X-Content-Type-Options: nosniff
+Content-Type: application/json; odata.metadata=minimal
+OData-Version: 4.0
+
+{"error": "precondition failed"}
+--$boundary--
+EOD;
+
+        $headers = ['Content-Type' => "multipart/mixed; boundary=$boundary"];
+        $request = $this->createMock(IODataRequest::class);
+
+        $batchResponse = new ODataBatchResponse($request, $body, 200, $headers);
+        $responses = $batchResponse->getResponses();
+
+        $this->assertCount(1, $responses);
+        $this->assertSame(412, $responses[0]->getStatus());
+
+        $responseHeaders = $responses[0]->getHeaders();
+        $this->assertSame('298375c3-8565-40ba-87a4-e8b762a5c39b', $responseHeaders['REQ_ID']);
+        $this->assertSame('nosniff', $responseHeaders['X-Content-Type-Options']);
+        $this->assertSame('application/json; odata.metadata=minimal', $responseHeaders['Content-Type']);
+        $this->assertSame('4.0', $responseHeaders['OData-Version']);
+    }
+
+    public function testContentIDHeaderIsPreservedInChangesets(): void
+    {
+        $boundary = 'batch-boundary';
+        $changesetBoundary = 'changeset-boundary';
+
+        $body = <<<EOD
+--$boundary
+Content-Type: multipart/mixed; boundary=$changesetBoundary
+
+--$changesetBoundary
+Content-Type: application/http
+Content-ID: 1
+
+HTTP/1.1 201 Created
+Location: https://example.com/entity(1)
+
+--$changesetBoundary
+Content-Type: application/http
+Content-ID: 2
+
+HTTP/1.1 201 Created
+Location: https://example.com/entity(2)
+
+--$changesetBoundary--
+--$boundary--
+EOD;
+
+        $headers = ['Content-Type' => "multipart/mixed; boundary=$boundary"];
+        $request = $this->createMock(IODataRequest::class);
+
+        $batchResponse = new ODataBatchResponse($request, $body, 200, $headers);
+        $responses = $batchResponse->getResponses();
+
+        $this->assertCount(2, $responses);
+        $this->assertSame('1', $responses[0]->getHeaders()['Content-ID']);
+        $this->assertSame('2', $responses[1]->getHeaders()['Content-ID']);
+    }
+
+    public function testQuotedBoundaryIsHandled(): void
+    {
+        $boundary = 'quoted-boundary-123';
+        $body = <<<EOD
+--$boundary
+Content-Type: application/http
+
+HTTP/1.1 200 OK
+
+[]
+--$boundary--
+EOD;
+
+        $headers = ['Content-Type' => "multipart/mixed; boundary=\"$boundary\""];
+        $request = $this->createMock(IODataRequest::class);
+
+        $batchResponse = new ODataBatchResponse($request, $body, 200, $headers);
+        $this->assertCount(1, $batchResponse->getResponses());
+    }
+}

--- a/tests/ODataBatchResponseTest.php
+++ b/tests/ODataBatchResponseTest.php
@@ -184,6 +184,10 @@ EOD;
         $this->assertSame('[Organization URI]/api/data/v9.2/contacts(66aa66aa-bb77-cc88-dd99-00ee00ee00ee)', $headers2['Location']);
         $this->assertSame('[Organization URI]/api/data/v9.2/contacts(66aa66aa-bb77-cc88-dd99-00ee00ee00ee)', $headers2['OData-EntityId']);
         $this->assertSame('', $response2->getRawBody());
+
+        $this->assertSame($response1, $batchResponse->getResponseByContentId('1'));
+        $this->assertSame($response2, $batchResponse->getResponseByContentId('2'));
+        $this->assertNull($batchResponse->getResponseByContentId('3'));
     }
 
     public function testBatchResponseWithMixedSuccessAndFailure(): void

--- a/tests/ODataResponseFactoryTest.php
+++ b/tests/ODataResponseFactoryTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace SaintSystems\OData\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SaintSystems\OData\ODataResponseFactory;
+use SaintSystems\OData\ODataResponse;
+use SaintSystems\OData\ODataBatchResponse;
+use SaintSystems\OData\IODataRequest;
+
+class ODataResponseFactoryTest extends TestCase
+{
+    public function testCreateReturnsODataResponseForNonBatchContent(): void
+    {
+        $request = $this->createMock(IODataRequest::class);
+        $headers = ['Content-Type' => 'application/json'];
+        $body = '{"test": "data"}';
+
+        $response = ODataResponseFactory::create($request, $body, 200, $headers);
+
+        $this->assertInstanceOf(ODataResponse::class, $response);
+        $this->assertNotInstanceOf(ODataBatchResponse::class, $response);
+        $this->assertSame(200, $response->getStatus());
+    }
+
+    public function testCreateReturnsBatchResponseForMultipartMixedContent(): void
+    {
+        $request = $this->createMock(IODataRequest::class);
+        $boundary = 'batch_boundary_123';
+        $headers = ['Content-Type' => "multipart/mixed; boundary=$boundary"];
+        $body = "--$boundary\nContent-Type: application/http\n\nHTTP/1.1 200 OK\n\n[]\n--$boundary--";
+
+        $response = ODataResponseFactory::create($request, $body, 200, $headers);
+
+        $this->assertInstanceOf(ODataBatchResponse::class, $response);
+    }
+
+    public function testCreateReturnsBatchResponseWithQuotedBoundary(): void
+    {
+        $request = $this->createMock(IODataRequest::class);
+        $boundary = 'batch_boundary_456';
+        $headers = ['Content-Type' => "multipart/mixed; boundary=\"$boundary\""];
+        $body = "--$boundary\nContent-Type: application/http\n\nHTTP/1.1 200 OK\n\n[]\n--$boundary--";
+
+        $response = ODataResponseFactory::create($request, $body, 200, $headers);
+
+        $this->assertInstanceOf(ODataBatchResponse::class, $response);
+    }
+
+    public function testCreateReturnsBatchResponseWithSingleQuotedBoundary(): void
+    {
+        $request = $this->createMock(IODataRequest::class);
+        $boundary = 'batch_boundary_789';
+        $headers = ['Content-Type' => "multipart/mixed; boundary='$boundary'"];
+        $body = "--$boundary\nContent-Type: application/http\n\nHTTP/1.1 200 OK\n\n[]\n--$boundary--";
+
+        $response = ODataResponseFactory::create($request, $body, 200, $headers);
+
+        $this->assertInstanceOf(ODataBatchResponse::class, $response);
+    }
+
+    public function testCreateReturnsODataResponseForMissingContentType(): void
+    {
+        $request = $this->createMock(IODataRequest::class);
+        $headers = ['test' => 'header'];
+        $body = '{"test": "data"}';
+
+        $response = ODataResponseFactory::create($request, $body, 200, $headers);
+
+        $this->assertInstanceOf(ODataResponse::class, $response);
+        $this->assertNotInstanceOf(ODataBatchResponse::class, $response);
+    }
+
+    public function testCreateHandlesContentTypeAsArray(): void
+    {
+        $request = $this->createMock(IODataRequest::class);
+        $boundary = 'array_boundary';
+        $headers = ['Content-Type' => ["multipart/mixed; boundary=$boundary", 'charset=utf-8']];
+        $body = "--$boundary\nContent-Type: application/http\n\nHTTP/1.1 200 OK\n\n[]\n--$boundary--";
+
+        $response = ODataResponseFactory::create($request, $body, 200, $headers);
+
+        $this->assertInstanceOf(ODataBatchResponse::class, $response);
+    }
+
+    public function testCreateReturnsODataResponseForArrayContentTypeWithoutBoundary(): void
+    {
+        $request = $this->createMock(IODataRequest::class);
+        $headers = ['Content-Type' => ['application/json', 'charset=utf-8']];
+        $body = '{"test": "data"}';
+
+        $response = ODataResponseFactory::create($request, $body, 200, $headers);
+
+        $this->assertInstanceOf(ODataResponse::class, $response);
+        $this->assertNotInstanceOf(ODataBatchResponse::class, $response);
+    }
+
+    public function testCreateHandlesCaseInsensitiveContentTypeHeader(): void
+    {
+        $request = $this->createMock(IODataRequest::class);
+        $boundary = 'case_boundary';
+        $headers = ['content-type' => "multipart/mixed; boundary=$boundary"];
+        $body = "--$boundary\nContent-Type: application/http\n\nHTTP/1.1 200 OK\n\n[]\n--$boundary--";
+
+        $response = ODataResponseFactory::create($request, $body, 200, $headers);
+
+        $this->assertInstanceOf(ODataBatchResponse::class, $response);
+    }
+
+    public function testCreateHandlesMixedCaseContentTypeHeader(): void
+    {
+        $request = $this->createMock(IODataRequest::class);
+        $boundary = 'mixed_case_boundary';
+        $headers = ['Content-TYPE' => "multipart/mixed; boundary=$boundary"];
+        $body = "--$boundary\nContent-Type: application/http\n\nHTTP/1.1 200 OK\n\n[]\n--$boundary--";
+
+        $response = ODataResponseFactory::create($request, $body, 200, $headers);
+
+        $this->assertInstanceOf(ODataBatchResponse::class, $response);
+    }
+
+    public function testCreateWithEmptyBody(): void
+    {
+        $request = $this->createMock(IODataRequest::class);
+        $headers = ['Content-Type' => 'application/json'];
+
+        $response = ODataResponseFactory::create($request, '', 200, $headers);
+
+        $this->assertInstanceOf(ODataResponse::class, $response);
+        $this->assertSame(200, $response->getStatus());
+    }
+
+    public function testCreateWithMultipleHeadersIncludingBatchContentType(): void
+    {
+        $request = $this->createMock(IODataRequest::class);
+        $boundary = 'multi_header_boundary';
+        $headers = [
+            'Accept' => 'application/json',
+            'Content-Type' => "multipart/mixed; boundary=$boundary",
+            'OData-Version' => '4.0',
+            'Authorization' => 'Bearer token'
+        ];
+        $body = "--$boundary\nContent-Type: application/http\n\nHTTP/1.1 200 OK\n\n[]\n--$boundary--";
+
+        $response = ODataResponseFactory::create($request, $body, 200, $headers);
+
+        $this->assertInstanceOf(ODataBatchResponse::class, $response);
+        $this->assertSame($headers, $response->getHeaders());
+    }
+
+    public function testCreateWithBoundaryContainingSpecialCharacters(): void
+    {
+        $request = $this->createMock(IODataRequest::class);
+        $boundary = 'batch-boundary_123.456+789';
+        $headers = ['Content-Type' => "multipart/mixed; boundary=$boundary"];
+        $body = "--$boundary\nContent-Type: application/http\n\nHTTP/1.1 200 OK\n\n[]\n--$boundary--";
+
+        $response = ODataResponseFactory::create($request, $body, 200, $headers);
+
+        $this->assertInstanceOf(ODataBatchResponse::class, $response);
+    }
+
+    public function testCreateWithWhitespaceAroundBoundary(): void
+    {
+        $request = $this->createMock(IODataRequest::class);
+        $boundary = 'whitespace_boundary';
+        // Extra whitespace around boundary
+        $headers = ['Content-Type' => "multipart/mixed;  boundary=$boundary"];
+        $body = "--$boundary\nContent-Type: application/http\n\nHTTP/1.1 200 OK\n\n[]\n--$boundary--";
+
+        $response = ODataResponseFactory::create($request, $body, 200, $headers);
+
+        $this->assertInstanceOf(ODataBatchResponse::class, $response);
+    }
+
+    public function testCreatePreservesAllParametersInResponse(): void
+    {
+        $request = $this->createMock(IODataRequest::class);
+        $headers = ['Content-Type' => 'application/json; charset=utf-8', 'X-Custom' => 'value'];
+        $body = '{"id": 123, "name": "test"}';
+        $statusCode = 201;
+
+        $response = ODataResponseFactory::create($request, $body, $statusCode, $headers);
+
+        $this->assertInstanceOf(ODataResponse::class, $response);
+        $this->assertSame($statusCode, $response->getStatus());
+        $this->assertSame($body, $response->getRawBody());
+        $this->assertSame($headers, $response->getHeaders());
+    }
+}


### PR DESCRIPTION
Currently, there is no way to make full use of the batch API as response handling is limited.

This PR introduces support for user-friendly batch api response handling, by introducing a `ODataBatchResponse` that contains an array of individual `ODataResponse` objects, as well as some other minor improvements.