### PR TITLE
chore: add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.4 || ^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4",
         "nesbot/carbon": "^2.0 || ^3.0",
-        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0 || ^2.0"


### PR DESCRIPTION
### Summary
The upstream package `saintsystems/odata-client-php` does not yet support Laravel 13. This fork adds that support to unblock the iHawk Laravel 13 upgrade.

PR extends the `illuminate/support` version constraint to include Laravel 13, allowing this package to be used in Laravel 13 applications.

### Changes
- Updated composer.json to add ^13.0 to the illuminate/support version constraint

